### PR TITLE
Upgraded TSM Loops function to use MG

### DIFF
--- a/include/qudaQKXTM_Kepler.h
+++ b/include/qudaQKXTM_Kepler.h
@@ -493,9 +493,10 @@ void calcMG_loop_wOneD_TSM_wExact(void **gaugeToPlaquette,
 				  QudaInvertParam *param,
 				  QudaGaugeParam *gauge_param, 
 				  quda::qudaQKXTM_arpackInfo arpackInfo,
-				  quda::qudaQKXTM_arpackInfo arpackInfoEO, 
 				  quda::qudaQKXTM_loopInfo loopInfo, 
 				  quda::qudaQKXTMinfo_Kepler info);
 #endif
+// HAVE_ARPACK
 
 #endif
+//_QUDAQKXTM_KEPLER_H

--- a/include/qudaQKXTM_Kepler_utils.h
+++ b/include/qudaQKXTM_Kepler_utils.h
@@ -109,7 +109,6 @@ namespace quda {
     // = { false  , false,  true   , true    ,  true  ,  true}
     bool loop_oneD[6];
     bool useTSM;
-    bool fullOp_stochEO;
     int TSM_NHP;
     int TSM_NLP;
     int TSM_NdumpHP;

--- a/include/qudaQKXTM_Kepler_utils.h
+++ b/include/qudaQKXTM_Kepler_utils.h
@@ -94,7 +94,6 @@ namespace quda {
     unsigned long int seed;
     int Ndump;
     char loop_fname[512];
-    int smethod;
 #ifdef HAVE_ARPACK
     int nSteps_defl;
     int deflStep[MAX_DEFLSTEPS];

--- a/lib/blas_magma.cu
+++ b/lib/blas_magma.cu
@@ -14,7 +14,7 @@
 #define MAGMA_17 //default version version of the MAGMA library
 
 #ifdef MAGMA_LIB
-#include </users/howarth/GCC/magma-1.7.0/include/magma.h>
+#include <magma.h>
 
 #ifdef MAGMA_14
 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -6049,7 +6049,7 @@ void calcMG_threepTwop_EvenOdd(void **gauge_APE, void **gauge,
   if(param->gamma_basis != QUDA_UKQCD_GAMMA_BASIS) 
     errorQuda("%s: This function works only with ukqcd gamma basis\n", fname);
   if(param->dirac_order != QUDA_DIRAC_ORDER) 
-    errorQuda("%s: This function works only with colors inside the spins\n, fname");
+    errorQuda("%s: This function works only with colors inside the spins\n", fname);
 
   if( param->matpc_type == QUDA_MATPC_EVEN_EVEN )
     flag_eo = true;
@@ -6098,7 +6098,7 @@ void calcMG_threepTwop_EvenOdd(void **gauge_APE, void **gauge,
   for(int i=0;i<info.Nsources;i++) nRun3pt += info.run3pt_src[i];
 
   int NprojMax = 0;
-  if(nRun3pt==0) printfQuda("Will NOT perform the three-point function for any of the source positions\n", fname);
+  if(nRun3pt==0) printfQuda("%s: Will NOT perform the three-point function for any of the source positions\n", fname);
   else if (nRun3pt>0){
     printfQuda("Will perform the three-point function for %d source positions, for the following source-sink separations and projectors:\n",nRun3pt);
     for(int its=0;its<info.Ntsink;its++){
@@ -6175,25 +6175,25 @@ void calcMG_threepTwop_EvenOdd(void **gauge_APE, void **gauge,
   //Settings for HDF5 data write format
   if( CorrFileFormat==HDF5_FORM ){
     if( Thrp_local_HDF5 == NULL ) 
-      errorQuda("%s: Cannot allocate memory for Thrp_local_HDF5.\n");
+      errorQuda("%s: Cannot allocate memory for Thrp_local_HDF5.\n",fname);
     if( Thrp_noether_HDF5 == NULL ) 
-      errorQuda("%s: Cannot allocate memory for Thrp_noether_HDF5.\n");
+      errorQuda("%s: Cannot allocate memory for Thrp_noether_HDF5.\n",fname);
 
     memset(Thrp_local_HDF5  , 0, 2*16*alloc_size*2*info.Ntsink*NprojMax*sizeof(double));
     memset(Thrp_noether_HDF5, 0, 2* 4*alloc_size*2*info.Ntsink*NprojMax*sizeof(double));
 
     if( Thrp_oneD_HDF5 == NULL ) 
-      errorQuda("%s: Cannot allocate memory for Thrp_oneD_HDF5.\n");
+      errorQuda("%s: Cannot allocate memory for Thrp_oneD_HDF5.\n",fname);
     for(int mu=0;mu<4;mu++){
       if( Thrp_oneD_HDF5[mu] == NULL ) 
-	errorQuda("%s: Cannot allocate memory for Thrp_oned_HDF5[%d].\n",mu);      
+	errorQuda("%s: Cannot allocate memory for Thrp_oned_HDF5[%d].\n",fname,mu);      
       memset(Thrp_oneD_HDF5[mu], 0, 2*16*alloc_size*2*info.Ntsink*NprojMax*sizeof(double));
     }
     
     if( Twop_baryons_HDF5 == NULL ) 
-      errorQuda("%s: Cannot allocate memory for Twop_baryons_HDF5.\n");
+      errorQuda("%s: Cannot allocate memory for Twop_baryons_HDF5.\n",fname);
     if( Twop_mesons_HDF5  == NULL ) 
-      errorQuda("%s: Cannot allocate memory for Twop_mesons_HDF5.\n");
+      errorQuda("%s: Cannot allocate memory for Twop_mesons_HDF5.\n",fname);
 
     memset(Twop_baryons_HDF5, 0, 2*16*alloc_size*2*N_BARYONS*sizeof(double));
     memset(Twop_mesons_HDF5 , 0, 2   *alloc_size*2*N_MESONS *sizeof(double));
@@ -8071,7 +8071,7 @@ void calcMG_loop_wOneD_TSM_wExact(void **gaugeToPlaquette,
   pushVerbosity(param->verbosity);
   if (getVerbosity() >= QUDA_DEBUG_VERBOSE) printQudaInvertParam(param);
   
-  printfQuda("\n### %s: Loop calculation begins now\n\n");
+  printfQuda("\n### %s: Loop calculation begins now\n\n",fname);
 
   //-Checks for exact deflation part 
   profileInvert.TPSTART(QUDA_PROFILE_TOTAL);
@@ -8080,10 +8080,10 @@ void calcMG_loop_wOneD_TSM_wExact(void **gaugeToPlaquette,
     errorQuda("Only asymmetric operators are supported in deflation\n");
   if( arpackInfo.isEven    && 
       (EvInvParam->matpc_type != QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) ) 
-    errorQuda("%s: Inconsistency between operator types!");
+    errorQuda("%s: Inconsistency between operator types!",fname);
   if( (!arpackInfo.isEven) && 
       (EvInvParam->matpc_type != QUDA_MATPC_ODD_ODD_ASYMMETRIC) )   
-    errorQuda("%s: Inconsistency between operator types!");
+    errorQuda("%s: Inconsistency between operator types!",fname);
 
   //-Checks for stochastic approximation and generalities 
   if(param->inv_type != QUDA_GCR_INVERTER) 
@@ -8715,7 +8715,7 @@ void calcMG_loop_wOneD_TSM_wExact(void **gaugeToPlaquette,
   K_gauge->calculatePlaq();
 
   // QKXTM: DMH Calculation should default to these settings.
-  printfQuda("%s: Will solve the stochastic part using Multigrid.\n");
+  printfQuda("%s: Will solve the stochastic part using Multigrid.\n",fname);
 
   // QKXTM: DMH This is a fairly arbitrary setting in terms of
   //        solver performance. 

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -7729,6 +7729,10 @@ void calcMG_loop_wOneD_TSM_EvenOdd(void **gaugeToPlaquette,
       K_vector->packVector((double*) input_vector);
       K_vector->loadVector();
       K_vector->uploadToCuda(b,flag_eo);
+
+      blas::zero(*out);
+      blas::zero(*out_LP);
+
       dirac.prepare(in,out,*x,*b,param->solution_type);
       dirac.prepare(in,out_LP,*x_LP,*b,param->solution_type);
       // in is reference to the b but for a parity singlet
@@ -9079,6 +9083,10 @@ void calcMG_loop_wOneD_TSM_wExact(void **gaugeToPlaquette,
       K_vector->packVector((double*) input_vector);
       K_vector->loadVector();
       K_vector->uploadToCuda(b,flag_eo);
+      
+      blas::zero(*out);
+      blas::zero(*out_LP);
+      
       // in -> b, out -> x, for parity singlets
       dirac.prepare(in,out   ,*x   ,*b,param->solution_type); 
       dirac.prepare(in,out_LP,*x_LP,*b,param->solution_type);

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -9451,8 +9451,6 @@ void calcMG_loop_wOneD_TSM_wExact(void **gaugeToPlaquette,
     delete x_LP;
   }
 
-  //if(stochEO) delete deflationEO;
-
   printfQuda("...Done\n");
   popVerbosity();
   saveTuneCache();

--- a/lib/interface_quda.cpp
+++ b/lib/interface_quda.cpp
@@ -7069,6 +7069,1443 @@ void calcMG_threepTwop_EvenOdd(void **gauge_APE, void **gauge,
 
 }
 
+
+////////////////////////////////
+// QKXTM Eigenvector routines //
+////////////////////////////////
+
+#ifdef HAVE_ARPACK
+
+void calcMG_loop_wOneD_TSM_wExact(void **gaugeToPlaquette, 
+				  QudaInvertParam *EvInvParam, 
+				  QudaInvertParam *param, 
+				  QudaGaugeParam *gauge_param,
+				  qudaQKXTM_arpackInfo arpackInfo, 
+				  qudaQKXTM_loopInfo loopInfo, 
+				  qudaQKXTMinfo_Kepler info){
+
+  double t1,t2,t3,t4;
+  char fname[256];
+  sprintf(fname, "calcMG_loop_wOneD_TSM_wExact");
+  
+  //======================================================================//
+  //================= P A R A M E T E R   C H E C K S ====================//
+  //======================================================================//
+
+  if (!initialized) 
+    errorQuda("%s: QUDA not initialized", fname);
+  pushVerbosity(param->verbosity);
+  if (getVerbosity() >= QUDA_DEBUG_VERBOSE) printQudaInvertParam(param);
+  
+  printfQuda("\n### %s: Loop calculation begins now\n\n",fname);
+
+  //-Checks for exact deflation part 
+  profileInvert.TPSTART(QUDA_PROFILE_TOTAL);
+  if( (EvInvParam->matpc_type != QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) && 
+      (EvInvParam->matpc_type != QUDA_MATPC_ODD_ODD_ASYMMETRIC) ) 
+    errorQuda("Only asymmetric operators are supported in deflation\n");
+  if( arpackInfo.isEven    && 
+      (EvInvParam->matpc_type != QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) ) 
+    errorQuda("%s: Inconsistency between operator types!",fname);
+  if( (!arpackInfo.isEven) && 
+      (EvInvParam->matpc_type != QUDA_MATPC_ODD_ODD_ASYMMETRIC) )   
+    errorQuda("%s: Inconsistency between operator types!",fname);
+
+  //-Checks for stochastic approximation and generalities 
+  if(param->inv_type != QUDA_GCR_INVERTER) 
+    errorQuda("%s: This function works only with GCR method", fname);  
+  if(param->gamma_basis != QUDA_UKQCD_GAMMA_BASIS) 
+    errorQuda("%s: This function works only with ukqcd gamma basis\n",fname);
+  if(param->dirac_order != QUDA_DIRAC_ORDER) 
+    errorQuda("%s: This function works only with color-inside-spin\n",fname);
+  
+  //Stochastic, momentum, and data dump information.
+  int Nstoch = loopInfo.Nstoch;
+  unsigned long int seed = loopInfo.seed;
+  int Ndump = loopInfo.Ndump;
+  int Nprint = loopInfo.Nprint;
+  loopInfo.Nmoms = GK_Nmoms;
+  int Nmoms = GK_Nmoms;
+  char filename_out[512];
+
+  FILE_WRITE_FORMAT LoopFileFormat = loopInfo.FileFormat;
+
+  char loop_exact_fname[512];
+  char loop_stoch_fname[512];
+
+  //-C.K. Truncated solver method params
+  bool useTSM = loopInfo.useTSM;
+  int TSM_NHP = loopInfo.TSM_NHP;
+  int TSM_NLP = loopInfo.TSM_NLP;
+  int TSM_NdumpHP = loopInfo.TSM_NdumpHP;
+  int TSM_NdumpLP = loopInfo.TSM_NdumpLP;
+  int TSM_NprintHP = loopInfo.TSM_NprintHP;
+  int TSM_NprintLP = loopInfo.TSM_NprintLP;
+  long int TSM_maxiter = 0;
+  double TSM_tol = 0.0;
+  if( (loopInfo.TSM_tol == 0) && 
+      (loopInfo.TSM_maxiter !=0 ) ) {
+    // LP criterion fixed by iteration number
+    TSM_maxiter = loopInfo.TSM_maxiter;
+  }
+  else if( (loopInfo.TSM_tol != 0) && 
+	   (loopInfo.TSM_maxiter == 0) ) {
+    // LP criterion fixed by tolerance
+    TSM_tol = loopInfo.TSM_tol;
+  }
+  else if( useTSM && 
+	   (loopInfo.TSM_tol != 0) && 
+	   (loopInfo.TSM_maxiter != 0) ){
+    warningQuda("Both max-iter = %ld and tolerance = %lf defined as criterions for the TSM. Proceeding with max-iter = %ld criterion.\n",
+		loopInfo.TSM_maxiter,
+		loopInfo.TSM_tol,
+		loopInfo.TSM_maxiter);
+    // LP criterion fixed by iteration number
+    TSM_maxiter = loopInfo.TSM_maxiter;
+  }
+
+  // std-ultra_local
+  loopInfo.loop_type[0] = "Scalar"; 
+  loopInfo.loop_oneD[0] = false;
+  // gen-ultra_local
+  loopInfo.loop_type[1] = "dOp";    
+  loopInfo.loop_oneD[1] = false;   
+  // std-one_derivative
+  loopInfo.loop_type[2] = "Loops";  
+  loopInfo.loop_oneD[2] = true;    
+  // std-conserved current
+  loopInfo.loop_type[3] = "LoopsCv";
+  loopInfo.loop_oneD[3] = true;    
+  // gen-one_derivative
+  loopInfo.loop_type[4] = "LpsDw";  
+  loopInfo.loop_oneD[4] = true;   
+  // gen-conserved current 
+  loopInfo.loop_type[5] = "LpsDwCv";
+  loopInfo.loop_oneD[5] = true;   
+
+  printfQuda("\nLoop Calculation Info\n");
+  printfQuda("=====================\n");
+  if(useTSM){
+    printfQuda(" Will perform the Truncated Solver method using the following parameters:\n");
+    printfQuda("  -N_HP = %d\n",TSM_NHP);
+    printfQuda("  -N_LP = %d\n",TSM_NLP);
+    if (TSM_maxiter == 0) printfQuda("  -CG stopping criterion is: tol = %e\n",TSM_tol);
+    else printfQuda("  -CG stopping criterion is: max-iter = %ld\n",TSM_maxiter);
+    printfQuda("  -Will dump every %d high-precision noise vectors, thus %d times\n",TSM_NdumpHP,TSM_NprintHP);
+    printfQuda("  -Will dump every %d low-precision noise vectors , thus %d times\n",TSM_NdumpLP,TSM_NprintLP);
+  }
+  else{
+    printfQuda(" Will not perform the Truncated Solver method\n");
+    printfQuda(" No. of noise vectors: %d\n",Nstoch);
+    printfQuda(" Will dump every %d noise vectors, thus %d times\n",Ndump,Nprint);
+  }
+  printfQuda(" The seed is: %ld\n",seed);
+  printfQuda(" The conf trajectory is: %04d\n",loopInfo.traj);
+  printfQuda(" Will produce the loop for %d Momentum Combinations\n",Nmoms);
+  printfQuda(" The loop file format is %s\n", (LoopFileFormat == ASCII_FORM) ? "ASCII" : "HDF5");
+  printfQuda(" The loop base name is %s\n",loopInfo.loop_fname);
+  printfQuda(" Will perform the loop for the following %d numbers of eigenvalues:",loopInfo.nSteps_defl);
+  for(int s=0;s<loopInfo.nSteps_defl;s++){
+    printfQuda("  %d",loopInfo.deflStep[s]);
+  }
+  if(info.source_type==RANDOM) printfQuda(" Will use RANDOM stochastic sources\n");
+  else if (info.source_type==UNITY) printfQuda(" Will use UNITY stochastic sources\n");
+  printfQuda("=====================\n\n");
+  
+  bool exact_part = true;
+  bool stoch_part = false;
+
+  bool LowPrecSum = true;
+  bool HighPrecSum = false;
+
+  //======================================================================//
+  //================ M E M O R Y   A L L O C A T I O N ===================// 
+  //======================================================================//
+
+  //- Allocate memory for accumulation buffers
+  void *std_uloc[loopInfo.nSteps_defl];
+  void *gen_uloc[loopInfo.nSteps_defl];
+  void *tmp_loop;
+
+  void **std_oneD[loopInfo.nSteps_defl];
+  void **gen_oneD[loopInfo.nSteps_defl];
+  void **std_csvC[loopInfo.nSteps_defl];
+  void **gen_csvC[loopInfo.nSteps_defl];
+
+  for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){  
+    //- ultra-local loops
+    if((cudaHostAlloc(&(std_uloc[dstep]), 
+		      sizeof(double)*2*16*GK_localVolume, 
+		      cudaHostAllocMapped)) != cudaSuccess)
+      errorQuda("%s: Error allocating memory std_uloc[%d]\n",fname,dstep);
+    if((cudaHostAlloc(&(gen_uloc[dstep]), 
+		      sizeof(double)*2*16*GK_localVolume, 
+		      cudaHostAllocMapped)) != cudaSuccess)
+      errorQuda("%s: Error allocating memory gen_uloc[%d]\n",fname,dstep);
+    if((cudaHostAlloc(&tmp_loop,          
+		      sizeof(double)*2*16*GK_localVolume, 
+		      cudaHostAllocMapped)) != cudaSuccess)
+      errorQuda("%s: Error allocating memory tmp_loop\n",fname);
+    
+    cudaMemset(std_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);
+    cudaMemset(gen_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);
+    cudaMemset(tmp_loop       , 0, sizeof(double)*2*16*GK_localVolume);
+    cudaDeviceSynchronize();
+
+    //- one-Derivative and conserved current loops
+    std_oneD[dstep] = (void**) malloc(sizeof(double*)*4);
+    gen_oneD[dstep] = (void**) malloc(sizeof(double*)*4);
+    std_csvC[dstep] = (void**) malloc(sizeof(double*)*4);
+    gen_csvC[dstep] = (void**) malloc(sizeof(double*)*4);
+    
+    if(std_oneD[dstep] == NULL) 
+      errorQuda("%s: Error allocating memory std_oneD[%d]\n",fname,dstep);
+    if(gen_oneD[dstep] == NULL) 
+      errorQuda("%s: Error allocating memory gen_oneD[%d]\n",fname,dstep);
+    if(std_csvC[dstep] == NULL) 
+      errorQuda("%s: Error allocating memory std_csvC[%d]\n",fname,dstep);
+    if(gen_csvC[dstep] == NULL) 
+      errorQuda("%s: Error allocating memory gen_csvC[%d]\n",fname,dstep);
+    cudaDeviceSynchronize();
+    
+    for(int mu = 0; mu < 4 ; mu++){
+      if((cudaHostAlloc(&(std_oneD[dstep][mu]), 
+			sizeof(double)*2*16*GK_localVolume, 
+			cudaHostAllocMapped)) != cudaSuccess)
+	errorQuda("%s: Error allocating memory std_oneD[%d][%d]\n",
+		  fname,dstep,mu);
+      if((cudaHostAlloc(&(gen_oneD[dstep][mu]), 
+			sizeof(double)*2*16*GK_localVolume, 
+			cudaHostAllocMapped)) != cudaSuccess)
+	errorQuda("%s: Error allocating memory gen_oneD[%d][%d]\n",
+		  fname,dstep,mu);
+      if((cudaHostAlloc(&(std_csvC[dstep][mu]), 
+			sizeof(double)*2*16*GK_localVolume, 
+			cudaHostAllocMapped)) != cudaSuccess)
+	errorQuda("%s: Error allocating memory std_csvC[%d][%d]\n",
+		  fname,dstep,mu);
+      if((cudaHostAlloc(&(gen_csvC[dstep][mu]), 
+			sizeof(double)*2*16*GK_localVolume, 
+			cudaHostAllocMapped)) != cudaSuccess)
+	errorQuda("%s: Error allocating memory gen_csvC[%d][%d]\n",
+		  fname,dstep,mu);
+      
+      cudaMemset(std_oneD[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
+      cudaMemset(gen_oneD[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
+      cudaMemset(std_csvC[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
+      cudaMemset(gen_csvC[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
+    }
+    cudaDeviceSynchronize();
+  }//-dstep
+  printfQuda("%s: Accumulation buffers memory allocated properly.\n",fname);
+  //--------------------------------------
+  
+  //-Allocate memory for the write buffers
+  int Nprt = ( useTSM ? TSM_NprintLP : Nprint );
+
+  double *buf_std_uloc[loopInfo.nSteps_defl];
+  double *buf_gen_uloc[loopInfo.nSteps_defl];
+  double **buf_std_oneD[loopInfo.nSteps_defl];
+  double **buf_gen_oneD[loopInfo.nSteps_defl];
+  double **buf_std_csvC[loopInfo.nSteps_defl];
+  double **buf_gen_csvC[loopInfo.nSteps_defl];
+
+  for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
+
+    buf_std_uloc[dstep] = 
+      (double*)malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
+    buf_gen_uloc[dstep] = 
+      (double*)malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
+
+    buf_std_oneD[dstep] = (double**) malloc(sizeof(double*)*4);
+    buf_gen_oneD[dstep] = (double**) malloc(sizeof(double*)*4);  
+    buf_std_csvC[dstep] = (double**) malloc(sizeof(double*)*4);
+    buf_gen_csvC[dstep] = (double**) malloc(sizeof(double*)*4);
+    
+    if( buf_std_uloc[dstep] == NULL ) 
+      errorQuda("Allocation of buffer buf_std_uloc[%d] failed.\n",dstep);
+    if( buf_gen_uloc[dstep] == NULL ) 
+      errorQuda("Allocation of buffer buf_gen_uloc[%d] failed.\n",dstep);
+    
+    if( buf_std_oneD[dstep] == NULL ) 
+      errorQuda("Allocation of buffer buf_std_oneD[%d] failed.\n",dstep);
+    if( buf_gen_oneD[dstep] == NULL ) 
+      errorQuda("Allocation of buffer buf_gen_oneD[%d] failed.\n",dstep);
+    if( buf_std_csvC[dstep] == NULL ) 
+      errorQuda("Allocation of buffer buf_std_csvC[%d] failed.\n",dstep);
+    if( buf_gen_csvC[dstep] == NULL ) 
+      errorQuda("Allocation of buffer buf_gen_csvC[%d] failed.\n",dstep);
+    
+    for(int mu = 0; mu < 4 ; mu++){
+      buf_std_oneD[dstep][mu] = 
+	(double*) malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
+      buf_gen_oneD[dstep][mu] = 
+	(double*) malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
+      buf_std_csvC[dstep][mu] = 
+	(double*) malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
+      buf_gen_csvC[dstep][mu] = 
+	(double*) malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
+      
+      if( buf_std_oneD[dstep][mu] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_oneD[%d][%d] failed.\n",
+		 dstep,mu);
+      if( buf_gen_oneD[dstep][mu] == NULL ) 
+	errorQuda("Allocation of buffer buf_gen_oneD[%d][%d] failed.\n",
+		  dstep,mu);
+      if( buf_std_csvC[dstep][mu] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_csvC[%d][%d] failed.\n",
+		  dstep,mu);
+      if( buf_gen_csvC[dstep][mu] == NULL ) 
+	errorQuda("Allocation of buffer buf_gen_csvC[%d][%d] failed.\n",
+		  dstep,mu);
+    }
+  }
+  
+  //- Allocate extra memory if using TSM
+  void *std_uloc_LP[loopInfo.nSteps_defl];
+  void *gen_uloc_LP[loopInfo.nSteps_defl];
+  void **std_oneD_LP[loopInfo.nSteps_defl];
+  void **gen_oneD_LP[loopInfo.nSteps_defl];
+  void **std_csvC_LP[loopInfo.nSteps_defl];
+  void **gen_csvC_LP[loopInfo.nSteps_defl];
+
+  double *buf_std_uloc_LP[loopInfo.nSteps_defl];
+  double *buf_gen_uloc_LP[loopInfo.nSteps_defl];
+  double *buf_std_uloc_HP[loopInfo.nSteps_defl];
+  double *buf_gen_uloc_HP[loopInfo.nSteps_defl];
+
+  double **buf_std_oneD_LP[loopInfo.nSteps_defl];
+  double **buf_gen_oneD_LP[loopInfo.nSteps_defl];
+  double **buf_std_csvC_LP[loopInfo.nSteps_defl];
+  double **buf_gen_csvC_LP[loopInfo.nSteps_defl];
+  double **buf_std_oneD_HP[loopInfo.nSteps_defl];
+  double **buf_gen_oneD_HP[loopInfo.nSteps_defl]; 
+  double **buf_std_csvC_HP[loopInfo.nSteps_defl]; 
+  double **buf_gen_csvC_HP[loopInfo.nSteps_defl];
+  
+  if(useTSM){
+    for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
+      //- low-precision accumulation buffers, ultra-local
+      if((cudaHostAlloc(&(std_uloc_LP[dstep]), 
+			sizeof(double)*2*16*GK_localVolume, 
+			cudaHostAllocMapped)) != cudaSuccess)
+	errorQuda("%s: Error allocating memory std_uloc_LP[%d]\n",
+		  fname,dstep);
+
+      if((cudaHostAlloc(&(gen_uloc_LP[dstep]), 
+			sizeof(double)*2*16*GK_localVolume, 
+			cudaHostAllocMapped)) != cudaSuccess)
+	errorQuda("%s: Error allocating memory gen_uloc_LP[%d]\n",
+		  fname,dstep);
+      
+      cudaMemset(std_uloc_LP[dstep], 0, sizeof(double)*2*16*GK_localVolume);
+      cudaMemset(gen_uloc_LP[dstep], 0, sizeof(double)*2*16*GK_localVolume);
+      cudaDeviceSynchronize();
+      
+      //- low-precision accumulation buffers, 
+      // one-Derivative and conserved current
+      std_oneD_LP[dstep] = (void**) malloc(4*sizeof(double*));
+      gen_oneD_LP[dstep] = (void**) malloc(4*sizeof(double*));
+      std_csvC_LP[dstep] = (void**) malloc(4*sizeof(double*));
+      gen_csvC_LP[dstep] = (void**) malloc(4*sizeof(double*));
+      
+      if(gen_oneD_LP[dstep] == NULL) 
+	errorQuda("%s: Error allocating memory gen_oneD_LP[%d]\n",
+		  fname,dstep);
+      if(std_oneD_LP[dstep] == NULL) 
+	errorQuda("%s: Error allocating memory std_oneD_LP[%d]\n",
+		  fname,dstep);
+      if(gen_csvC_LP[dstep] == NULL) 
+	errorQuda("%s: Error allocating memory gen_csvC_LP[%d]\n",
+		  fname,dstep);
+      if(std_csvC_LP[dstep] == NULL) 
+	errorQuda("%s: Error allocating memory std_csvC_LP[%d]\n",
+		  fname,dstep);
+      cudaDeviceSynchronize();
+      
+      for(int mu = 0; mu < 4 ; mu++){
+	if((cudaHostAlloc(&(std_oneD_LP[dstep][mu]), 
+			  sizeof(double)*2*16*GK_localVolume, 
+			  cudaHostAllocMapped)) != cudaSuccess)
+	  errorQuda("%s: Error allocating memory std_oneD_LP[%d][%d]\n",
+		    fname,dstep,mu);
+
+	if((cudaHostAlloc(&(gen_oneD_LP[dstep][mu]), 
+			  sizeof(double)*2*16*GK_localVolume, 
+			  cudaHostAllocMapped)) != cudaSuccess)
+	  errorQuda("%s: Error allocating memory gen_oneD_LP[%d][%d]\n",
+		    fname,dstep,mu);
+
+	if((cudaHostAlloc(&(std_csvC_LP[dstep][mu]), 
+			  sizeof(double)*2*16*GK_localVolume, 
+			  cudaHostAllocMapped)) != cudaSuccess)
+	  errorQuda("%s: Error allocating memory std_csvC_LP[%d][%d]\n",
+		    fname,dstep,mu);
+	
+	if((cudaHostAlloc(&(gen_csvC_LP[dstep][mu]), 
+			  sizeof(double)*2*16*GK_localVolume, 
+			  cudaHostAllocMapped)) != cudaSuccess)
+	  errorQuda("%s: Error allocating memory gen_csvC_LP[%d][%d]\n",
+		    fname,dstep,mu);    
+	
+	cudaMemset(std_oneD_LP[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);
+	cudaMemset(gen_oneD_LP[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);
+	cudaMemset(std_csvC_LP[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);
+	cudaMemset(gen_csvC_LP[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);
+      }
+      cudaDeviceSynchronize();
+      //------------------------------
+
+
+      //-write buffers for Low-precision loops      
+      buf_std_uloc_LP[dstep] = 
+	(double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+      buf_gen_uloc_LP[dstep] = 
+	(double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+
+      buf_std_oneD_LP[dstep] = (double**)malloc(4*sizeof(double*));
+      buf_gen_oneD_LP[dstep] = (double**)malloc(4*sizeof(double*));
+      buf_std_csvC_LP[dstep] = (double**)malloc(4*sizeof(double*));
+      buf_gen_csvC_LP[dstep] = (double**)malloc(4*sizeof(double*));
+
+      if( buf_std_uloc_LP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_uloc_LP[%d] failed.",dstep);
+      if( buf_gen_uloc_LP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_gen_uloc_LP[%d] failed.",dstep);
+      
+      if( buf_std_oneD_LP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_oneD_LP[%d] failed.",dstep);
+      if( buf_gen_oneD_LP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_oneD_LP[%d] failed.",dstep);
+      if( buf_std_csvC_LP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_oneD_LP[%d] failed.",dstep);
+      if( buf_gen_csvC_LP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_oneD_LP[%d] failed.",dstep);
+
+      for(int mu = 0; mu < 4 ; mu++){
+
+      buf_std_oneD_LP[dstep][mu] = 
+        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+      buf_gen_oneD_LP[dstep][mu] = 
+        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+      buf_std_csvC_LP[dstep][mu] = 
+        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+      buf_gen_csvC_LP[dstep][mu] = 
+        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+      
+      if(buf_std_oneD_LP[dstep][mu] == NULL) 
+	errorQuda("Allocation of buffer buf_std_oneD_LP[%d][%d] failed.",
+		  dstep,mu);
+      if(buf_gen_oneD_LP[dstep][mu] == NULL) 
+	errorQuda("Allocation of buffer buf_std_oneD_LP[%d][%d] failed.",
+		  dstep,mu);
+      if(buf_std_csvC_LP[dstep][mu] == NULL) 
+	errorQuda("Allocation of buffer buf_std_oneD_LP[%d][%d] failed.",
+		   dstep,mu);
+      if(buf_gen_csvC_LP[dstep][mu] == NULL) 
+	errorQuda("Allocation of buffer buf_std_oneD_LP[%d][%d] failed.",
+		   dstep,mu);
+      }
+      
+      //-write buffers for High-precision loops
+      buf_std_uloc_HP[dstep] = 
+	(double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+      buf_gen_uloc_HP[dstep] = 
+	(double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+
+      buf_std_oneD_HP[dstep] = (double**)malloc(4*sizeof(double*));
+      buf_gen_oneD_HP[dstep] = (double**)malloc(4*sizeof(double*));
+      buf_std_csvC_HP[dstep] = (double**)malloc(4*sizeof(double*));
+      buf_gen_csvC_HP[dstep] = (double**)malloc(4*sizeof(double*));
+
+      if( buf_std_uloc_HP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_uloc_HP[%d] failed.",dstep);
+      if( buf_gen_uloc_HP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_gen_uloc_HP[%d] failed.",dstep);
+      
+      if( buf_std_oneD_HP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_oneD_HP[%d] failed.",dstep);
+      if( buf_gen_oneD_HP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_oneD_HP[%d] failed.",dstep);
+      if( buf_std_csvC_HP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_oneD_HP[%d] failed.",dstep);
+      if( buf_gen_csvC_HP[dstep] == NULL ) 
+	errorQuda("Allocation of buffer buf_std_oneD_HP[%d] failed.",dstep);
+
+      for(int mu = 0; mu < 4 ; mu++){
+
+      buf_std_oneD_HP[dstep][mu] = 
+        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+      buf_gen_oneD_HP[dstep][mu] = 
+        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+      buf_std_csvC_HP[dstep][mu] = 
+        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+      buf_gen_csvC_HP[dstep][mu] = 
+        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
+      
+      if(buf_std_oneD_HP[dstep][mu] == NULL) 
+	errorQuda("Allocation of buffer buf_std_oneD_HP[%d][%d] failed.",
+		  dstep,mu);
+      if(buf_gen_oneD_HP[dstep][mu] == NULL) 
+	errorQuda("Allocation of buffer buf_std_oneD_HP[%d][%d] failed.",
+		  dstep,mu);
+      if(buf_std_csvC_HP[dstep][mu] == NULL) 
+	errorQuda("Allocation of buffer buf_std_oneD_HP[%d][%d] failed.",
+		   dstep,mu);
+      if(buf_gen_csvC_HP[dstep][mu] == NULL) 
+	errorQuda("Allocation of buffer buf_std_oneD_HP[%d][%d] failed.",
+		   dstep,mu);
+      }
+
+    }//-dsetp
+  }//-if useTSM
+
+  printfQuda("%s: Write buffers memory allocated properly.\n",fname);
+  //--------------------------------------
+
+  //-Allocate the momenta
+  int **mom,**momQsq;
+  long int SplV = GK_totalL[0]*GK_totalL[1]*GK_totalL[2];
+  mom =    (int**) malloc(sizeof(int*)*SplV);
+  momQsq = (int**) malloc(sizeof(int*)*Nmoms);
+  if(mom    == NULL) errorQuda("Error in allocating mom\n");
+  if(momQsq == NULL) errorQuda("Error in allocating momQsq\n");
+  
+  for(int ip=0; ip<SplV; ip++) {
+    mom[ip] = (int*) malloc(sizeof(int)*3);
+    if(mom[ip] == NULL) errorQuda("Error in allocating mom[%d]\n",ip);
+  }
+  for(int ip=0; ip<Nmoms; ip++) {
+    momQsq[ip] = (int *) malloc(sizeof(int)*3);
+    if(momQsq[ip] == NULL) errorQuda("Error in allocating momQsq[%d]\n",ip);
+  }
+  createLoopMomenta(mom,momQsq,info.Q_sq,Nmoms);
+  printfQuda("%s: Momenta created\n",fname);
+
+  //======================================================================//
+  //========== E X A C T   P R O B L E M   C O N S T R U C T =============// 
+  //======================================================================//
+
+  // QKXTM: DMH Here the low modes of the normal M^{\dagger}M 
+  //        operator are constructed. The correlation function
+  //        values are calculated at every Nth deflation step:
+  //        Nth = loopInfo.deflStep[s]
+  
+  printfQuda("\n ### Exact part calculation ###\n");
+
+  int NeV_Full = arpackInfo.nEv;  
+  
+  //Create object to store and calculate eigenpairs
+  QKXTM_Deflation_Kepler<double> *deflation = 
+    new QKXTM_Deflation_Kepler<double>(param,arpackInfo);
+  deflation->printInfo();
+  
+
+  //- Calculate the eigenVectors
+  t1 = MPI_Wtime(); 
+  deflation->eigenSolver();
+  t2 = MPI_Wtime();
+  printfQuda("%s TIME REPORT:",fname);
+  printfQuda("Full Operator EigenVector Calculation: %f sec\n",t2-t1);
+
+  deflation->MapEvenOddToFull();
+
+  //- Calculate the exact part of the loop
+  int iPrint = 0;
+  int s = 0;
+  for(int n=0;n<NeV_Full;n++){
+    t1 = MPI_Wtime();
+    deflation->Loop_w_One_Der_FullOp_Exact(n, EvInvParam, 
+					   gen_uloc[0], std_uloc[0], 
+					   gen_oneD[0], std_oneD[0], 
+					   gen_csvC[0], std_csvC[0]);
+    t2 = MPI_Wtime();
+    printfQuda("TIME_REPORT: Exact part for EV %d done in: %f sec\n",
+	       n+1,t2-t1);
+    
+    if( (n+1)==loopInfo.deflStep[s] ){     
+      if(GK_nProc[2]==1){      
+	doCudaFFT_v2<double>(std_uloc[0], tmp_loop); // Scalar
+	copyLoopToWriteBuf(buf_std_uloc[0], tmp_loop,
+			   iPrint, info.Q_sq, Nmoms,mom);
+	doCudaFFT_v2<double>(gen_uloc[0], tmp_loop); // dOp
+	copyLoopToWriteBuf(buf_gen_uloc[0], tmp_loop, 
+			   iPrint, info.Q_sq, Nmoms,mom);
+	
+	for(int mu = 0 ; mu < 4 ; mu++){
+	  doCudaFFT_v2<double>(std_oneD[0][mu], tmp_loop); // Loops
+	  copyLoopToWriteBuf(buf_std_oneD[0][mu], tmp_loop,
+			     iPrint, info.Q_sq, Nmoms,mom);
+	  doCudaFFT_v2<double>(std_csvC[0][mu], tmp_loop); // LoopsCv
+	  copyLoopToWriteBuf(buf_std_csvC[0][mu], tmp_loop, 
+			     iPrint, info.Q_sq, Nmoms, mom);
+	  
+	  doCudaFFT_v2<double>(gen_oneD[0][mu], tmp_loop); // LpsDw
+	  copyLoopToWriteBuf(buf_gen_oneD[0][mu], tmp_loop, 
+			     iPrint, info.Q_sq, Nmoms, mom);
+	  doCudaFFT_v2<double>(gen_csvC[0][mu], tmp_loop); // LpsDwCv
+	  copyLoopToWriteBuf(buf_gen_csvC[0][mu], tmp_loop, 
+			     iPrint, info.Q_sq, Nmoms, mom);
+	}
+	printfQuda("Exact part of Loops for NeV = %d copied to write buffers\n",n+1);
+      }
+      else if(GK_nProc[2]>1){
+	t1 = MPI_Wtime();
+	performFFT<double>(buf_std_uloc[0], std_uloc[0], 
+			   iPrint, Nmoms, momQsq);
+	performFFT<double>(buf_gen_uloc[0], gen_uloc[0], 
+			   iPrint, Nmoms, momQsq);
+	
+	for(int mu=0;mu<4;mu++){
+	  performFFT<double>(buf_std_oneD[0][mu], std_oneD[0][mu], 
+			     iPrint, Nmoms, momQsq);
+	  performFFT<double>(buf_std_csvC[0][mu], std_csvC[0][mu], 
+			     iPrint, Nmoms, momQsq);
+	  performFFT<double>(buf_gen_oneD[0][mu], gen_oneD[0][mu], 
+			     iPrint, Nmoms, momQsq);
+	  performFFT<double>(buf_gen_csvC[0][mu], gen_csvC[0][mu], 
+			     iPrint, Nmoms, momQsq);
+	}
+	t2 = MPI_Wtime();
+	printfQuda("TIME_REPORT: FFT and copying to Write Buffers is %f sec\n",t2-t1);
+      }
+
+      //================================================================//
+      //=============== D U M P   E X A C T   D A T A  =================// 
+      //================================================================//
+
+      //-Write the exact part of the loop
+      sprintf(loop_exact_fname,"%s_exact_NeV%d",loopInfo.loop_fname,n+1);
+      if(LoopFileFormat==ASCII_FORM){ // Write the loops in ASCII format
+	// Scalar
+	writeLoops_ASCII(buf_std_uloc[0], loop_exact_fname, 
+			 loopInfo, momQsq, 0, 0, exact_part, false, false);
+	// dOp
+	writeLoops_ASCII(buf_gen_uloc[0], loop_exact_fname, 
+			 loopInfo, momQsq, 1, 0, exact_part, false ,false);
+	for(int mu = 0 ; mu < 4 ; mu++){
+	  // Loops
+	  writeLoops_ASCII(buf_std_oneD[0][mu], loop_exact_fname, 
+			   loopInfo, momQsq, 2, mu, exact_part,false,false);
+	  // LoopsCv 
+	  writeLoops_ASCII(buf_std_csvC[0][mu], loop_exact_fname, 
+			   loopInfo, momQsq, 3, mu, exact_part,false,false);
+	  // LpsDw
+	  writeLoops_ASCII(buf_gen_oneD[0][mu], loop_exact_fname, 
+			   loopInfo, momQsq, 4, mu, exact_part,false,false);
+	  // LpsDwCv 
+	  writeLoops_ASCII(buf_gen_csvC[0][mu], loop_exact_fname, 
+			   loopInfo, momQsq, 5, mu, exact_part,false,false); 
+	}
+      }
+      else if(LoopFileFormat==HDF5_FORM){
+	// Write the loops in HDF5 format
+	writeLoops_HDF5(buf_std_uloc[0], buf_gen_uloc[0], 
+			buf_std_oneD[0], buf_std_csvC[0], 
+			buf_gen_oneD[0], buf_gen_csvC[0], 
+			loop_exact_fname, loopInfo, 
+			momQsq, exact_part, false, false);
+      }
+      
+      printfQuda("Writing the Exact part of the loops for NeV = %d completed.\n",n+1);
+      s++;
+    }//-if
+  }//-for NeV_Full
+  
+  printfQuda("\n ### Exact part calculation Done ###\n");
+
+  //=====================================================================//
+  //======  S T O C H A S T I C   P R O B L E M   C O N S T R U C T =====//
+  //=====================================================================//
+
+  //QKXTM: DMH Here we calculate the contribution to the All-to-All
+  //       propagator from stochastic sources. In previous versions
+  //       of this code, deflation was used to accelerate the inversions
+  //       using either a deflation operator from the exact part with a 
+  //       normal (M^+M \phi = M^+ \eta) solve type, or exact deflation 
+  //       and an extra Even/Odd preconditioned deflation step on the 
+  //       remainder.
+  //       Due to the direct solve limitation of MG, we can longer use
+  //       the exact part to accelerate the problem execution. We
+  //       therefore simply solve for the stochastic source using MG,
+  //       then project out the exact contribution from the solution.
+
+  printfQuda("\n ### Stochastic part calculation ###\n\n");
+
+  cudaGaugeField *cudaGauge = checkGauge(param);
+  checkInvertParam(param);
+
+  QKXTM_Gauge_Kepler<double> *K_gauge = 
+    new QKXTM_Gauge_Kepler<double>(BOTH,GAUGE);
+  K_gauge->packGauge(gaugeToPlaquette);
+  K_gauge->loadGauge();
+  K_gauge->calculatePlaq();
+
+  // QKXTM: DMH Calculation should default to these settings.
+  printfQuda("%s: Will solve the stochastic part using Multigrid.\n",fname);
+
+  // QKXTM: DMH This is a fairly arbitrary setting in terms of
+  //        solver performance. 
+  bool flag_eo = false;
+
+  // QKXTM: DMH EO preconditioned solves offer x2
+  //        speed up, we should always use it.
+  bool pc_solve = true;
+
+  // QKXTM: DMH we MUST construct the full solution spinor
+  //        in order to properly project out the exact part.
+  bool pc_solution = false;
+
+  bool mat_solution = 
+    (param->solution_type == QUDA_MAT_SOLUTION) || 
+    (param->solution_type == QUDA_MATPC_SOLUTION);
+  // QKXTM: DMH MG can only use DIRECT solves.
+  bool direct_solve = true;
+
+  param->spinorGiB = cudaGauge->VolumeCB() * spinorSiteSize;
+  if (!pc_solve) param->spinorGiB *= 2;
+  param->spinorGiB *= (param->cuda_prec == QUDA_DOUBLE_PRECISION ? sizeof(double) : sizeof(float));
+  if (param->preserve_source == QUDA_PRESERVE_SOURCE_NO) {
+    param->spinorGiB *= (param->inv_type == QUDA_CG_INVERTER ? 5 : 7)/(double)(1<<30);
+  } else {
+    param->spinorGiB *= (param->inv_type == QUDA_CG_INVERTER ? 8 : 9)/(double)(1<<30);
+  }
+  param->secs = 0;
+  param->gflops = 0;
+  param->iter = 0;
+
+  Dirac *d = NULL;
+  Dirac *dSloppy = NULL;
+  Dirac *dPre = NULL;
+  createDirac(d, dSloppy, dPre, *param, pc_solve);
+  Dirac &dirac = *d;
+  Dirac &diracSloppy = *dSloppy;
+  Dirac &diracPre = *dPre;
+  profileInvert.TPSTART(QUDA_PROFILE_H2D);
+
+
+  ColorSpinorField *b = NULL;
+  ColorSpinorField *x = NULL;
+  ColorSpinorField *in = NULL;
+  ColorSpinorField *out = NULL;
+  ColorSpinorField *sol    = NULL;
+  ColorSpinorField *sol_LP = NULL;
+  ColorSpinorField *tmp3 = NULL;
+  ColorSpinorField *tmp4 = NULL;
+  ColorSpinorField *x_LP   = NULL;
+  ColorSpinorField *out_LP = NULL;
+
+  const int *X = cudaGauge->X();
+
+  void *input_vector = malloc(X[0]*X[1]*X[2]*X[3]*
+			      spinorSiteSize*sizeof(double));
+  void *output_vector = malloc(X[0]*X[1]*X[2]*X[3]*
+			       spinorSiteSize*sizeof(double));
+
+  memset(input_vector,0,X[0]*X[1]*X[2]*X[3]*spinorSiteSize*sizeof(double));
+  memset(output_vector,0,X[0]*X[1]*X[2]*X[3]*spinorSiteSize*sizeof(double));
+
+  // wrap CPU host side pointers
+  ColorSpinorParam cpuParam(input_vector, *param, X, 
+			    pc_solution, param->input_location);
+  ColorSpinorField *h_b = ColorSpinorField::Create(cpuParam);
+
+  cpuParam.v = output_vector;
+  cpuParam.location = param->output_location;
+  ColorSpinorField *h_x = ColorSpinorField::Create(cpuParam);
+
+  //Zero out the spinors
+  ColorSpinorParam cudaParam(cpuParam, *param);
+  cudaParam.create = QUDA_ZERO_FIELD_CREATE;
+  b    = new cudaColorSpinorField(*h_b, cudaParam);
+  x    = new cudaColorSpinorField(cudaParam);
+  tmp3 = new cudaColorSpinorField(cudaParam);
+  tmp4 = new cudaColorSpinorField(cudaParam);
+  if(useTSM) x_LP = new cudaColorSpinorField(cudaParam);
+  profileInvert.TPSTOP(QUDA_PROFILE_H2D);
+  setTuning(param->tune);
+
+  QKXTM_Vector_Kepler<double> *K_vector = 
+    new QKXTM_Vector_Kepler<double>(BOTH,VECTOR);
+  QKXTM_Vector_Kepler<double> *K_vecdef = 
+    new QKXTM_Vector_Kepler<double>(BOTH,VECTOR);
+
+  //Solver operators
+  DiracM m(dirac), mSloppy(diracSloppy), mPre(diracPre);
+
+  //-Set Randon Number Generator
+  gsl_rng *rNum = gsl_rng_alloc(gsl_rng_ranlux);
+  gsl_rng_set(rNum, seed + comm_rank()*seed);
+
+  //-Define the accumulation-sum limits
+  int Nrun;
+  int Nd;
+  char *msg_str;
+  if(useTSM){
+    Nrun = TSM_NLP;
+    Nd = TSM_NdumpLP;
+    asprintf(&msg_str,"NLP");
+  }
+  else{
+    Nrun = Nstoch;
+    Nd = Ndump;
+    asprintf(&msg_str,"Stoch.");
+  }
+
+  //- Prepare the accumulation buffers for the stochastic part
+  cudaMemset(tmp_loop, 0, sizeof(double)*2*16*GK_localVolume);
+  for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
+    cudaMemset(std_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);
+    cudaMemset(gen_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);
+    
+    for(int mu = 0; mu < 4 ; mu++){
+      cudaMemset(std_oneD[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
+      cudaMemset(gen_oneD[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
+      cudaMemset(std_csvC[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
+      cudaMemset(gen_csvC[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
+    }
+    cudaDeviceSynchronize();
+  }
+  //----------------
+  
+  int nDeflSteps;  
+  iPrint = -1;
+  for(int is = 0 ; is < Nrun ; is++){
+    t3 = MPI_Wtime();
+    t1 = MPI_Wtime();
+    memset(input_vector,0,X[0]*X[1]*X[2]*X[3]*spinorSiteSize*sizeof(double));
+    getStochasticRandomSource<double>(input_vector,rNum,info.source_type);
+
+    t2 = MPI_Wtime();
+    printfQuda("TIME_REPORT: %s %04d - Source creation: %f sec\n",
+	       msg_str,is+1,t2-t1);
+
+    K_vector->packVector((double*) input_vector);
+    K_vector->loadVector();
+    K_vector->uploadToCuda(b,flag_eo);
+    // in -> b, out -> x, for parity singlets
+    dirac.prepare(in,out,*x,*b,param->solution_type); 
+
+    //QKXTM: DMH No source preparation is required
+      
+    t1 = MPI_Wtime();
+    nDeflSteps = loopInfo.nSteps_defl;
+      
+    //If we are using the TSM, we need the LP
+    //solve for bias estimation. 
+    if(useTSM) {
+      //LP solve
+      double orig_tol = param->tol;
+      long int orig_maxiter = param->maxiter;
+      // Set the low-precision criterion
+      if(TSM_maxiter==0) param->tol = TSM_tol;
+      else if(TSM_tol==0) param->maxiter = TSM_maxiter;  
+      
+      // Create the low-precision solver
+      SolverParam solverParam_LP(*param);
+      Solver *solve_LP = Solver::create(solverParam_LP, m, mSloppy, 
+					mPre, profileInvert);
+      //LP solve
+      (*solve_LP)(*out,*in);
+      delete solve_LP;
+      
+      // Revert to the original, high-precision values
+      if(TSM_maxiter==0) param->tol = orig_tol;           
+      else if(TSM_tol==0) param->maxiter = orig_maxiter;
+    }
+    //Else, just do the HP solve.
+    else {
+      //HP solve
+      SolverParam solverParam(*param);
+      Solver *solve = Solver::create(solverParam, m, mSloppy, 
+				     mPre, profileInvert);
+      (*solve)(*out,*in);
+      delete solve;
+    }
+    
+    dirac.reconstruct(*x,*b,param->solution_type);
+    
+    sol = new cudaColorSpinorField(*x);    
+
+    for(int dstep=0;dstep<nDeflSteps;dstep++){
+      int NeV_defl = loopInfo.deflStep[dstep];
+      printfQuda("# Performing contractions for NeV = %d\n",NeV_defl);
+      
+      t1 = MPI_Wtime();	
+      K_vector->downloadFromCuda(sol,flag_eo);
+      K_vector->download();
+      
+      // Solution is projected and put into x, x <- (1-UU^dag) x
+      deflation->projectVector(*K_vecdef,*K_vector,is+1,NeV_defl);
+      K_vecdef->uploadToCuda(x,flag_eo);              
+      
+      t2 = MPI_Wtime();
+      printfQuda("TIME_REPORT: %s %04d - Solution projection: %f sec\n",
+		 msg_str,is+1,t2-t1);
+      
+      
+      t1 = MPI_Wtime();
+      oneEndTrick_w_One_Der<double>(*x, *tmp3, *tmp4, param, 
+				    gen_uloc[dstep], std_uloc[dstep], 
+				    gen_oneD[dstep], std_oneD[dstep], 
+				    gen_csvC[dstep], std_csvC[dstep]);
+      t2 = MPI_Wtime();
+      printfQuda("TIME_REPORT: %s %04d - Contractions: %f sec\n",
+		 msg_str,is+1,t2-t1);
+      
+      t4 = MPI_Wtime();
+      printfQuda("### TIME_REPORT: %s %04d - Finished in %f sec\n",
+		 msg_str,is+1,t4-t3);      
+      
+      if( (is+1)%Nd == 0){
+	if(dstep==0) iPrint++;
+	t1 = MPI_Wtime();
+	if(GK_nProc[2]==1){      
+	  doCudaFFT_v2<double>(std_uloc[dstep], tmp_loop); // Scalar
+	  copyLoopToWriteBuf(buf_std_uloc[dstep], tmp_loop, 
+			     iPrint, info.Q_sq, Nmoms, mom);
+	  doCudaFFT_v2<double>(gen_uloc[dstep], tmp_loop); // dOp
+	  copyLoopToWriteBuf(buf_gen_uloc[dstep], tmp_loop, 
+			     iPrint, info.Q_sq, Nmoms, mom);
+	    
+	  for(int mu = 0 ; mu < 4 ; mu++){
+	    doCudaFFT_v2<double>(std_oneD[dstep][mu], tmp_loop); // Loops
+	    copyLoopToWriteBuf(buf_std_oneD[dstep][mu], tmp_loop, 
+			       iPrint, info.Q_sq, Nmoms, mom);
+	    doCudaFFT_v2<double>(std_csvC[dstep][mu], tmp_loop); // LoopsCv
+	    copyLoopToWriteBuf(buf_std_csvC[dstep][mu], tmp_loop, 
+			       iPrint, info.Q_sq, Nmoms, mom);	      
+	    doCudaFFT_v2<double>(gen_oneD[dstep][mu],tmp_loop); // LpsDw
+	    copyLoopToWriteBuf(buf_gen_oneD[dstep][mu], tmp_loop, 
+			       iPrint, info.Q_sq, Nmoms, mom);
+	    doCudaFFT_v2<double>(gen_csvC[dstep][mu], tmp_loop); // LpsDwCv
+	    copyLoopToWriteBuf(buf_gen_csvC[dstep][mu], tmp_loop, 
+			       iPrint, info.Q_sq, Nmoms, mom);
+	  }
+	}
+	else if(GK_nProc[2]>1){
+	  performFFT<double>(buf_std_uloc[dstep], std_uloc[dstep], 
+			     iPrint, Nmoms, momQsq);
+	  performFFT<double>(buf_gen_uloc[dstep], gen_uloc[dstep], 
+			     iPrint, Nmoms, momQsq);
+	    
+	  for(int mu=0;mu<4;mu++){
+	    performFFT<double>(buf_std_oneD[dstep][mu], std_oneD[dstep][mu],
+			       iPrint, Nmoms, momQsq);
+	    performFFT<double>(buf_std_csvC[dstep][mu], std_csvC[dstep][mu],
+			       iPrint, Nmoms, momQsq);
+	    performFFT<double>(buf_gen_oneD[dstep][mu], gen_oneD[dstep][mu],
+			       iPrint, Nmoms, momQsq);
+	    performFFT<double>(buf_gen_csvC[dstep][mu], gen_csvC[dstep][mu],
+			       iPrint, Nmoms, momQsq);
+	  }
+	}
+	t2 = MPI_Wtime();
+	printfQuda("Loops for %s = %04d FFT'ed and copied to write buffers in %f sec\n",msg_str,is+1,t2-t1);
+      }//-if (is+1)
+    }//-deflation steps
+
+    delete sol;
+  }//-Nstoch
+
+  //======================================================================//
+  //================ D U M P   D A T A   A T   Nth EV ====================// 
+  //======================================================================//
+
+  //-Write the stochastic part of the loops
+  for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
+    int NeV_defl = loopInfo.deflStep[dstep];
+
+    t1 = MPI_Wtime();
+    sprintf(loop_stoch_fname,"%s_stoch%sNeV%d",
+	    loopInfo.loop_fname, useTSM ? "_TSM_" : "_", NeV_defl);
+    if(LoopFileFormat==ASCII_FORM){ 
+      // Write the loops in ASCII format
+      writeLoops_ASCII(buf_std_uloc[dstep], loop_stoch_fname, 
+		       loopInfo, momQsq, 0, 0, stoch_part, 
+		       useTSM, LowPrecSum); // Scalar
+      writeLoops_ASCII(buf_gen_uloc[dstep], loop_stoch_fname, 
+		       loopInfo, momQsq, 1, 0, stoch_part, 
+		       useTSM, LowPrecSum); // dOp
+      for(int mu = 0 ; mu < 4 ; mu++){
+	writeLoops_ASCII(buf_std_oneD[dstep][mu], loop_stoch_fname, 
+			 loopInfo, momQsq, 2, mu, stoch_part, 
+			 useTSM, LowPrecSum); // Loops
+	writeLoops_ASCII(buf_std_csvC[dstep][mu], loop_stoch_fname, 
+			 loopInfo, momQsq, 3, mu, stoch_part, 
+			 useTSM, LowPrecSum); // LoopsCv
+	writeLoops_ASCII(buf_gen_oneD[dstep][mu], loop_stoch_fname, 
+			 loopInfo, momQsq, 4, mu, stoch_part, 
+			 useTSM, LowPrecSum); // LpsDw
+	writeLoops_ASCII(buf_gen_csvC[dstep][mu], loop_stoch_fname, 
+			 loopInfo, momQsq, 5, mu, stoch_part, 
+			 useTSM, LowPrecSum); // LpsDwCv
+      }
+    }
+    else if(LoopFileFormat==HDF5_FORM){ 
+      // Write the loops in HDF5 format
+      writeLoops_HDF5(buf_std_uloc[dstep], buf_gen_uloc[dstep], 
+		      buf_std_oneD[dstep], buf_std_csvC[dstep], 
+		      buf_gen_oneD[dstep], buf_gen_csvC[dstep],
+		      loop_stoch_fname, loopInfo, momQsq, 
+		      stoch_part, useTSM, LowPrecSum);
+    }
+    t2 = MPI_Wtime();
+    printfQuda("Writing the Stochastic part of the loops for NeV = %d completed in %f sec.\n",NeV_defl,t2-t1);
+  }//-dstep
+
+
+  //- If using Truncated-Solver-Method, then proceed with
+  //- performing the loop calculation, for the low-precision and the 
+  //- high-precision inversions
+  if(useTSM){
+    //-Prepare the loops for the High- and Low-Precision
+    cudaMemset(tmp_loop, 0, sizeof(double)*2*16*GK_localVolume);
+    for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
+      cudaMemset(std_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);  
+      cudaMemset(std_uloc_LP[dstep], 0, sizeof(double)*2*16*GK_localVolume);
+      cudaMemset(gen_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);  
+      cudaMemset(gen_uloc_LP[dstep], 0, sizeof(double)*2*16*GK_localVolume);
+      
+      for(int mu = 0; mu < 4 ; mu++){
+	cudaMemset(std_oneD[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume); 
+	cudaMemset(std_oneD_LP[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);
+	cudaMemset(gen_oneD[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);  
+	cudaMemset(gen_oneD_LP[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);
+	cudaMemset(std_csvC[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);  
+	cudaMemset(std_csvC_LP[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);
+	cudaMemset(gen_csvC[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);  
+	cudaMemset(gen_csvC_LP[dstep][mu], 0, 
+		   sizeof(double)*2*16*GK_localVolume);
+      }
+      cudaDeviceSynchronize();
+    }
+    //-------------------------------------------------
+    
+    printfQuda("\nWill Perform the HP and LP inversions\n\n");
+
+    Nrun = TSM_NHP;
+    Nd = TSM_NdumpHP;
+    iPrint = -1;
+    for(int is = 0 ; is < Nrun ; is++){
+      t3 = MPI_Wtime();
+      t1 = MPI_Wtime();
+      memset(input_vector,0,
+	     GK_localL[0]*
+	     GK_localL[1]*
+	     GK_localL[2]*
+	     GK_localL[3]*spinorSiteSize*sizeof(double));
+
+      getStochasticRandomSource<double>(input_vector,rNum,info.source_type);
+
+      t2 = MPI_Wtime();
+      printfQuda("TIME_REPORT: %s %04d - Source creation: %f sec\n",
+		 msg_str,is+1,t2-t1);
+      K_vector->packVector((double*) input_vector);
+      K_vector->loadVector();
+      K_vector->uploadToCuda(b,flag_eo);
+      
+      blas::zero(*out);
+      blas::zero(*out_LP);
+      
+      // in -> b, out -> x, for parity singlets
+      dirac.prepare(in,out   ,*x   ,*b,param->solution_type); 
+      dirac.prepare(in,out_LP,*x_LP,*b,param->solution_type);
+
+      t1 = MPI_Wtime();
+	
+      //HP solve
+      //-------------------------------------------------
+      SolverParam solverParam(*param);
+      Solver *solve = Solver::create(solverParam, m, mSloppy, mPre, 
+				     profileInvert);
+      (*solve)   (*out,*in);
+      delete solve;
+      dirac.reconstruct(*x,*b,param->solution_type);
+      //-------------------------------------------------
+      
+      
+      //LP solve
+      //-------------------------------------------------
+      double orig_tol = param->tol;
+      long int orig_maxiter = param->maxiter;
+      // Set the low-precision criterion
+      if(TSM_maxiter==0) param->tol = TSM_tol;
+      else if(TSM_tol==0) param->maxiter = TSM_maxiter;  
+      
+      // Create the low-precision solver
+      SolverParam solverParam_LP(*param);
+      Solver *solve_LP = Solver::create(solverParam_LP, m, mSloppy, 
+					mPre, profileInvert);
+      (*solve_LP)(*out_LP,*in);
+      delete solve_LP;
+      dirac.reconstruct(*x_LP,*b,param->solution_type);
+      
+      // Revert to the original, high-precision values
+      if(TSM_maxiter==0) param->tol = orig_tol;           
+      else if(TSM_tol==0) param->maxiter = orig_maxiter;      
+      //-------------------------------------------------
+      
+      sol    = new cudaColorSpinorField(*x);
+      sol_LP = new cudaColorSpinorField(*x_LP);
+    
+      for(int dstep=0;dstep<nDeflSteps;dstep++){
+	int NeV_defl = loopInfo.deflStep[dstep];
+	printfQuda("# Performing TSM contractions for NeV = %d\n",NeV_defl);
+	
+	t1 = MPI_Wtime();
+	K_vector->downloadFromCuda(sol,flag_eo);
+	K_vector->download();
+	deflation->projectVector(*K_vecdef,*K_vector,is+1,NeV_defl);
+	
+	// Solution is projected and put into x, x <- (1-UU^dag) x
+	K_vecdef->uploadToCuda(x,flag_eo);
+	t2 = MPI_Wtime();
+	printfQuda("TIME_REPORT: NHP %04d - HP sol projection: %f sec\n",
+		   is+1,t2-t1);	  
+	
+	t1 = MPI_Wtime();
+	K_vector->downloadFromCuda(sol_LP,flag_eo);
+	K_vector->download();
+	
+	// Solution is projected and put into x, x <- (1-UU^dag) x
+	deflation->projectVector(*K_vecdef,*K_vector,is+1,NeV_defl);
+	K_vecdef->uploadToCuda(x_LP,flag_eo);
+	t2 = MPI_Wtime();
+	printfQuda("TIME_REPORT: NHP %04d - LP sol projection: %f sec\n",
+		   is+1,t2-t1);
+      
+	
+	// Contractions
+	//-------------------------------------------------
+	t1 = MPI_Wtime();
+	//-high-precision
+	oneEndTrick_w_One_Der<double>(*x, *tmp3, *tmp4,param, 
+				      gen_uloc[dstep], std_uloc[dstep], 
+				      gen_oneD[dstep], std_oneD[dstep], 
+				      gen_csvC[dstep], std_csvC[dstep]); 
+	t2 = MPI_Wtime();
+	printfQuda("TIME_REPORT: NHP %04d - HP Contractions: %f sec\n",
+		   is+1,t2-t1);
+	t1 = MPI_Wtime();
+	//-low-precision
+	oneEndTrick_w_One_Der<double>(*x_LP, *tmp3, *tmp4,param, 
+				      gen_uloc_LP[dstep],std_uloc_LP[dstep],
+				      gen_oneD_LP[dstep],std_oneD_LP[dstep],
+				      gen_csvC_LP[dstep],std_csvC_LP[dstep]);
+	t2 = MPI_Wtime();
+	printfQuda("TIME_REPORT: NHP %04d - LP Contractions: %f sec\n",
+		   is+1,t2-t1);
+	
+	t4 = MPI_Wtime();
+	printfQuda("### TIME_REPORT: NHP %04d - Finished in %f sec\n",
+		   is+1,t4-t3);
+	
+	
+	// FFT and copy to write buffers
+	//-------------------------------------------------      
+	if( (is+1)%Nd == 0){
+	  if(dstep==0) iPrint++;
+	  t1 = MPI_Wtime();
+	  if(GK_nProc[2]==1){      
+	    doCudaFFT_v2<double>(std_uloc[dstep]   ,tmp_loop);  
+	    copyLoopToWriteBuf(buf_std_uloc_HP[dstep], tmp_loop, 
+				iPrint, info.Q_sq, Nmoms, mom); // Scalar
+	    doCudaFFT_v2<double>(std_uloc_LP[dstep],tmp_loop);  
+	    copyLoopToWriteBuf(buf_std_uloc_LP[dstep], tmp_loop, 
+			       iPrint, info.Q_sq, Nmoms, mom);
+
+	    doCudaFFT_v2<double>(gen_uloc[dstep]   ,tmp_loop);
+	    copyLoopToWriteBuf(buf_gen_uloc_HP[dstep], tmp_loop, 
+			       iPrint, info.Q_sq, Nmoms, mom); // dOp
+	    doCudaFFT_v2<double>(gen_uloc_LP[dstep],tmp_loop);  
+	    copyLoopToWriteBuf(buf_gen_uloc_LP[dstep], tmp_loop, 
+			       iPrint, info.Q_sq, Nmoms, mom);
+	    
+	    for(int mu = 0 ; mu < 4 ; mu++){
+	      doCudaFFT_v2<double>(std_oneD[dstep][mu]   ,tmp_loop);  
+	      copyLoopToWriteBuf(buf_std_oneD_HP[dstep][mu], tmp_loop, 
+				 iPrint,info.Q_sq,Nmoms,mom); // Loops
+	      doCudaFFT_v2<double>(std_oneD_LP[dstep][mu], tmp_loop);  
+	      copyLoopToWriteBuf(buf_std_oneD_LP[dstep][mu], tmp_loop,
+				 iPrint,info.Q_sq,Nmoms,mom);
+
+	      doCudaFFT_v2<double>(std_csvC[dstep][mu]   ,tmp_loop);  
+	      copyLoopToWriteBuf(buf_std_csvC_HP[dstep][mu], tmp_loop, 
+				 iPrint,info.Q_sq,Nmoms,mom); // LoopsCv
+	      doCudaFFT_v2<double>(std_csvC_LP[dstep][mu],tmp_loop);  
+	      copyLoopToWriteBuf(buf_std_csvC_LP[dstep][mu],tmp_loop,
+				 iPrint,info.Q_sq,Nmoms,mom);
+
+	      doCudaFFT_v2<double>(gen_oneD[dstep][mu]   ,tmp_loop);
+	      copyLoopToWriteBuf(buf_gen_oneD_HP[dstep][mu],tmp_loop,
+				 iPrint,info.Q_sq,Nmoms,mom); // LpsDw
+	      doCudaFFT_v2<double>(gen_oneD_LP[dstep][mu],tmp_loop);  
+	      copyLoopToWriteBuf(buf_gen_oneD_LP[dstep][mu],tmp_loop,
+				 iPrint,info.Q_sq,Nmoms,mom);
+	      doCudaFFT_v2<double>(gen_csvC[dstep][mu]   ,tmp_loop);  
+	      copyLoopToWriteBuf(buf_gen_csvC_HP[dstep][mu],tmp_loop,
+				 iPrint,info.Q_sq,Nmoms,mom); // LpsDwCv
+	      doCudaFFT_v2<double>(gen_csvC_LP[dstep][mu],tmp_loop);  
+	      copyLoopToWriteBuf(buf_gen_csvC_LP[dstep][mu],tmp_loop,
+				 iPrint,info.Q_sq,Nmoms,mom);
+	    }
+	  }
+	  else if(GK_nProc[2]>1){
+	    performFFT<double>(buf_std_uloc_HP[dstep], std_uloc[dstep], 
+			       iPrint, Nmoms, momQsq);  
+	    performFFT<double>(buf_std_uloc_LP[dstep], std_uloc_LP[dstep], 
+			       iPrint, Nmoms, momQsq);
+	    performFFT<double>(buf_gen_uloc_HP[dstep], gen_uloc[dstep], 
+			       iPrint, Nmoms, momQsq);  
+	    performFFT<double>(buf_gen_uloc_LP[dstep], gen_uloc_LP[dstep], 
+			       iPrint, Nmoms, momQsq);
+	    
+	    for(int mu=0;mu<4;mu++){
+	      performFFT<double>(buf_std_oneD_HP[dstep][mu], 
+				 std_oneD[dstep][mu], iPrint, 
+				 Nmoms, momQsq);  
+	      performFFT<double>(buf_std_oneD_LP[dstep][mu], 
+				 std_oneD_LP[dstep][mu], iPrint, 
+				 Nmoms, momQsq);
+	      performFFT<double>(buf_std_csvC_HP[dstep][mu], 
+				 std_csvC[dstep][mu], iPrint, 
+				 Nmoms, momQsq);  
+	      performFFT<double>(buf_std_csvC_LP[dstep][mu], 
+				 std_csvC_LP[dstep][mu], iPrint, 
+				 Nmoms, momQsq);
+	      performFFT<double>(buf_gen_oneD_HP[dstep][mu], 
+				 gen_oneD[dstep][mu], iPrint, 
+				 Nmoms, momQsq);  
+	      performFFT<double>(buf_gen_oneD_LP[dstep][mu], 
+				 gen_oneD_LP[dstep][mu], iPrint, 
+				 Nmoms, momQsq);
+	      performFFT<double>(buf_gen_csvC_HP[dstep][mu], 
+				 gen_csvC[dstep][mu], iPrint, 
+				 Nmoms, momQsq);  
+	      performFFT<double>(buf_gen_csvC_LP[dstep][mu], 
+				 gen_csvC_LP[dstep][mu], iPrint, 
+				 Nmoms, momQsq);
+	    }
+	  }
+	  t2 = MPI_Wtime();
+	  printfQuda("Loops for NHP = %04d FFT'ed and copied to write buffers in %f sec\n",is+1,t2-t1);
+	}//-if (is+1)
+      }//-deflation step
+
+      delete sol;
+      delete sol_LP;
+
+    }//-Nstoch
+    
+    //-Write the high-precision part
+    for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
+      int NeV_defl = loopInfo.deflStep[dstep];
+
+      t1 = MPI_Wtime();
+      sprintf(loop_stoch_fname,"%s_stoch_TSM_NeV%d_HighPrec",
+	      loopInfo.loop_fname, NeV_defl);
+      if(LoopFileFormat==ASCII_FORM){ 
+	// Write the loops in ASCII format
+	writeLoops_ASCII(buf_std_uloc_HP[dstep], loop_stoch_fname, 
+			 loopInfo, momQsq, 0, 0, 
+			 stoch_part, useTSM, HighPrecSum); // Scalar
+	writeLoops_ASCII(buf_gen_uloc_HP[dstep], loop_stoch_fname, 
+			 loopInfo, momQsq, 1, 0, stoch_part, 
+			 useTSM, HighPrecSum); // dOp
+	for(int mu = 0 ; mu < 4 ; mu++){
+	  writeLoops_ASCII(buf_std_oneD_HP[dstep][mu], loop_stoch_fname, 
+			   loopInfo, momQsq, 2, mu, 
+			   stoch_part, useTSM, HighPrecSum); // Loops
+	  writeLoops_ASCII(buf_std_csvC_HP[dstep][mu], loop_stoch_fname, 
+			   loopInfo, momQsq, 3, mu, 
+			   stoch_part, useTSM, HighPrecSum); // LoopsCv
+	  writeLoops_ASCII(buf_gen_oneD_HP[dstep][mu], loop_stoch_fname, 
+			   loopInfo, momQsq, 4, mu, 
+			   stoch_part, useTSM, HighPrecSum); // LpsDw
+	  writeLoops_ASCII(buf_gen_csvC_HP[dstep][mu], loop_stoch_fname, 
+			   loopInfo, momQsq, 5, mu, 
+			   stoch_part, useTSM, HighPrecSum); // LpsDwCv
+	}
+      }
+      else if(LoopFileFormat==HDF5_FORM){
+	// Write the loops in HDF5 format
+	writeLoops_HDF5(buf_std_uloc_HP[dstep], buf_gen_uloc_HP[dstep], 
+			buf_std_oneD_HP[dstep], buf_std_csvC_HP[dstep], 
+			buf_gen_oneD_HP[dstep], buf_gen_csvC_HP[dstep],
+			loop_stoch_fname, loopInfo, momQsq, 
+			stoch_part, useTSM, HighPrecSum);
+      }
+      t2 = MPI_Wtime();
+      printfQuda("Writing the high-precision loops for NeV = %d completed in %f sec.\n",NeV_defl,t2-t1);
+      
+      //-Write the low-precision part
+      t1 = MPI_Wtime();
+      sprintf(loop_stoch_fname,"%s_stoch_TSM_NeV%d_LowPrec",
+	      loopInfo.loop_fname, NeV_defl);
+      if(LoopFileFormat==ASCII_FORM){ 
+	// Write the loops in ASCII format
+	writeLoops_ASCII(buf_std_uloc_LP[dstep], loop_stoch_fname, 
+			 loopInfo, momQsq, 0, 0, 
+			 stoch_part, useTSM, HighPrecSum); // Scalar
+	writeLoops_ASCII(buf_gen_uloc_LP[dstep], loop_stoch_fname, 
+			 loopInfo, momQsq, 1, 0, 
+			 stoch_part, useTSM, HighPrecSum); // dOp
+	for(int mu = 0 ; mu < 4 ; mu++){
+	  writeLoops_ASCII(buf_std_oneD_LP[dstep][mu], loop_stoch_fname, 
+			   loopInfo, momQsq, 2, mu, 
+			   stoch_part, useTSM, HighPrecSum); // Loops
+	  writeLoops_ASCII(buf_std_csvC_LP[dstep][mu], loop_stoch_fname, 
+			   loopInfo, momQsq, 3, mu, 
+			   stoch_part, useTSM, HighPrecSum); // LoopsCv
+	  writeLoops_ASCII(buf_gen_oneD_LP[dstep][mu], loop_stoch_fname, 
+			   loopInfo, momQsq, 4, mu, 
+			   stoch_part, useTSM, HighPrecSum); // LpsDw
+	  writeLoops_ASCII(buf_gen_csvC_LP[dstep][mu], loop_stoch_fname, 
+			   loopInfo, momQsq, 5, mu, 
+			   stoch_part, useTSM, HighPrecSum); // LpsDwCv
+	}
+      }
+      else if(LoopFileFormat==HDF5_FORM){ 
+	// Write the loops in HDF5 format
+	writeLoops_HDF5(buf_std_uloc_LP[dstep], buf_gen_uloc_LP[dstep], 
+			buf_std_oneD_LP[dstep], buf_std_csvC_LP[dstep], 
+			buf_gen_oneD_LP[dstep], buf_gen_csvC_LP[dstep],
+			loop_stoch_fname, loopInfo, momQsq, 
+			stoch_part, useTSM, HighPrecSum);
+      }
+      t2 = MPI_Wtime();
+      printfQuda("Writing the low-precision loops for NeV = %d completed in %f sec.\n",NeV_defl,t2-t1);
+    }//-dstep
+    
+  }//-useTSM
+  
+  gsl_rng_free(rNum);
+  
+  printfQuda("\n ### Stochastic part calculation Done ###\n");
+
+  //======================================================================//
+  //================ M E M O R Y   C L E A N - U P =======================// 
+  //======================================================================//
+
+  printfQuda("\nCleaning up...\n");
+  
+  //-Free the momentum matrices
+  for(int ip=0; ip<SplV; ip++) free(mom[ip]);
+  free(mom);
+  for(int ip=0;ip<Nmoms;ip++) free(momQsq[ip]);
+  free(momQsq);
+  //---------------------------
+  
+  //-Free loop buffers
+  cudaFreeHost(tmp_loop);
+  for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
+    //-accumulation buffers
+    cudaFreeHost(std_uloc[dstep]);
+    cudaFreeHost(gen_uloc[dstep]);
+    for(int mu = 0 ; mu < 4 ; mu++){
+      cudaFreeHost(std_oneD[dstep][mu]);
+      cudaFreeHost(gen_oneD[dstep][mu]);
+      cudaFreeHost(std_csvC[dstep][mu]);
+      cudaFreeHost(gen_csvC[dstep][mu]);
+    }
+    free(std_oneD[dstep]);
+    free(gen_oneD[dstep]);
+    free(std_csvC[dstep]);
+    free(gen_csvC[dstep]);   
+    
+    //-write buffers
+    free(buf_std_uloc[dstep]);
+    free(buf_gen_uloc[dstep]);
+    for(int mu = 0 ; mu < 4 ; mu++){
+      free(buf_std_oneD[dstep][mu]);
+      free(buf_std_csvC[dstep][mu]);
+      free(buf_gen_oneD[dstep][mu]);
+      free(buf_gen_csvC[dstep][mu]);
+    }
+    free(buf_std_oneD[dstep]);
+    free(buf_std_csvC[dstep]);
+    free(buf_gen_oneD[dstep]);
+    free(buf_gen_csvC[dstep]);
+  }//-dstep
+  //---------------------------
+  
+  //-Free the extra buffers if using TSM
+  if(useTSM){
+    for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
+      cudaFreeHost(std_uloc_LP[dstep]);
+      cudaFreeHost(gen_uloc_LP[dstep]);
+      for(int mu = 0 ; mu < 4 ; mu++){
+	cudaFreeHost(std_oneD_LP[dstep][mu]);
+	cudaFreeHost(gen_oneD_LP[dstep][mu]);
+	cudaFreeHost(std_csvC_LP[dstep][mu]);
+	cudaFreeHost(gen_csvC_LP[dstep][mu]);
+      }
+      free(std_oneD_LP[dstep]);
+      free(gen_oneD_LP[dstep]);
+      free(std_csvC_LP[dstep]);
+      free(gen_csvC_LP[dstep]);
+     
+      free(buf_std_uloc_LP[dstep]); free(buf_std_uloc_HP[dstep]);
+      free(buf_gen_uloc_LP[dstep]); free(buf_gen_uloc_HP[dstep]);
+      for(int mu = 0 ; mu < 4 ; mu++){
+	free(buf_std_oneD_LP[dstep][mu]); free(buf_std_oneD_HP[dstep][mu]);
+	free(buf_std_csvC_LP[dstep][mu]); free(buf_std_csvC_HP[dstep][mu]);
+	free(buf_gen_oneD_LP[dstep][mu]); free(buf_gen_oneD_HP[dstep][mu]);
+	free(buf_gen_csvC_LP[dstep][mu]); free(buf_gen_csvC_HP[dstep][mu]);
+      }
+      free(buf_std_oneD_LP[dstep]); free(buf_std_oneD_HP[dstep]);
+      free(buf_std_csvC_LP[dstep]); free(buf_std_csvC_HP[dstep]);
+      free(buf_gen_oneD_LP[dstep]); free(buf_gen_oneD_HP[dstep]);
+      free(buf_gen_csvC_LP[dstep]); free(buf_gen_csvC_HP[dstep]);
+    }//-dstep
+  }//-useTSM
+  //------------------------------------
+
+  free(input_vector);
+  free(output_vector);
+
+  delete deflation;
+  delete d;
+  delete dSloppy;
+  delete dPre;
+  delete K_vecdef;
+  delete K_vector;
+  delete K_gauge;
+  delete x;
+  delete b;
+  delete tmp3;
+  delete tmp4;
+
+  if(useTSM){
+    delete x_LP;
+  }
+
+  printfQuda("...Done\n");
+  popVerbosity();
+  saveTuneCache();
+  profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
+}
+
+#endif
+
+
+//-===========================================================
+//- A D D I T I O N A L  D E P R E C A T E D   R O U T I N E S
+//-===========================================================
+
+
 void calcMG_loop_wOneD_TSM_EvenOdd(void **gaugeToPlaquette, 
 				   QudaInvertParam *param, 
 				   QudaGaugeParam *gauge_param, 
@@ -8043,1426 +9480,3 @@ void calcMG_loop_wOneD_TSM_EvenOdd(void **gaugeToPlaquette,
   saveTuneCache();
   profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
 }
-
-////////////////////////////////
-// QKXTM Eigenvector routines //
-////////////////////////////////
-
-#ifdef HAVE_ARPACK
-
-void calcMG_loop_wOneD_TSM_wExact(void **gaugeToPlaquette, 
-				  QudaInvertParam *EvInvParam, 
-				  QudaInvertParam *param, 
-				  QudaGaugeParam *gauge_param,
-				  qudaQKXTM_arpackInfo arpackInfo, 
-				  qudaQKXTM_loopInfo loopInfo, 
-				  qudaQKXTMinfo_Kepler info){
-
-  double t1,t2,t3,t4;
-  char fname[256];
-  sprintf(fname, "calcMG_loop_wOneD_TSM_wExact");
-  
-  //======================================================================//
-  //================= P A R A M E T E R   C H E C K S ====================//
-  //======================================================================//
-
-  if (!initialized) 
-    errorQuda("%s: QUDA not initialized", fname);
-  pushVerbosity(param->verbosity);
-  if (getVerbosity() >= QUDA_DEBUG_VERBOSE) printQudaInvertParam(param);
-  
-  printfQuda("\n### %s: Loop calculation begins now\n\n",fname);
-
-  //-Checks for exact deflation part 
-  profileInvert.TPSTART(QUDA_PROFILE_TOTAL);
-  if( (EvInvParam->matpc_type != QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) && 
-      (EvInvParam->matpc_type != QUDA_MATPC_ODD_ODD_ASYMMETRIC) ) 
-    errorQuda("Only asymmetric operators are supported in deflation\n");
-  if( arpackInfo.isEven    && 
-      (EvInvParam->matpc_type != QUDA_MATPC_EVEN_EVEN_ASYMMETRIC) ) 
-    errorQuda("%s: Inconsistency between operator types!",fname);
-  if( (!arpackInfo.isEven) && 
-      (EvInvParam->matpc_type != QUDA_MATPC_ODD_ODD_ASYMMETRIC) )   
-    errorQuda("%s: Inconsistency between operator types!",fname);
-
-  //-Checks for stochastic approximation and generalities 
-  if(param->inv_type != QUDA_GCR_INVERTER) 
-    errorQuda("%s: This function works only with GCR method", fname);  
-  if(param->gamma_basis != QUDA_UKQCD_GAMMA_BASIS) 
-    errorQuda("%s: This function works only with ukqcd gamma basis\n",fname);
-  if(param->dirac_order != QUDA_DIRAC_ORDER) 
-    errorQuda("%s: This function works only with color-inside-spin\n",fname);
-  
-  //Stochastic, momentum, and data dump information.
-  int Nstoch = loopInfo.Nstoch;
-  unsigned long int seed = loopInfo.seed;
-  int Ndump = loopInfo.Ndump;
-  int Nprint = loopInfo.Nprint;
-  loopInfo.Nmoms = GK_Nmoms;
-  int Nmoms = GK_Nmoms;
-  char filename_out[512];
-
-  FILE_WRITE_FORMAT LoopFileFormat = loopInfo.FileFormat;
-
-  char loop_exact_fname[512];
-  char loop_stoch_fname[512];
-
-  //-C.K. Truncated solver method params
-  bool useTSM = loopInfo.useTSM;
-  int TSM_NHP = loopInfo.TSM_NHP;
-  int TSM_NLP = loopInfo.TSM_NLP;
-  int TSM_NdumpHP = loopInfo.TSM_NdumpHP;
-  int TSM_NdumpLP = loopInfo.TSM_NdumpLP;
-  int TSM_NprintHP = loopInfo.TSM_NprintHP;
-  int TSM_NprintLP = loopInfo.TSM_NprintLP;
-  long int TSM_maxiter = 0;
-  double TSM_tol = 0.0;
-  if( (loopInfo.TSM_tol == 0) && 
-      (loopInfo.TSM_maxiter !=0 ) ) {
-    // LP criterion fixed by iteration number
-    TSM_maxiter = loopInfo.TSM_maxiter;
-  }
-  else if( (loopInfo.TSM_tol != 0) && 
-	   (loopInfo.TSM_maxiter == 0) ) {
-    // LP criterion fixed by tolerance
-    TSM_tol = loopInfo.TSM_tol;
-  }
-  else if( useTSM && 
-	   (loopInfo.TSM_tol != 0) && 
-	   (loopInfo.TSM_maxiter != 0) ){
-    warningQuda("Both max-iter = %ld and tolerance = %lf defined as criterions for the TSM. Proceeding with max-iter = %ld criterion.\n",
-		loopInfo.TSM_maxiter,
-		loopInfo.TSM_tol,
-		loopInfo.TSM_maxiter);
-    // LP criterion fixed by iteration number
-    TSM_maxiter = loopInfo.TSM_maxiter;
-  }
-
-  // std-ultra_local
-  loopInfo.loop_type[0] = "Scalar"; 
-  loopInfo.loop_oneD[0] = false;
-  // gen-ultra_local
-  loopInfo.loop_type[1] = "dOp";    
-  loopInfo.loop_oneD[1] = false;   
-  // std-one_derivative
-  loopInfo.loop_type[2] = "Loops";  
-  loopInfo.loop_oneD[2] = true;    
-  // std-conserved current
-  loopInfo.loop_type[3] = "LoopsCv";
-  loopInfo.loop_oneD[3] = true;    
-  // gen-one_derivative
-  loopInfo.loop_type[4] = "LpsDw";  
-  loopInfo.loop_oneD[4] = true;   
-  // gen-conserved current 
-  loopInfo.loop_type[5] = "LpsDwCv";
-  loopInfo.loop_oneD[5] = true;   
-
-  printfQuda("\nLoop Calculation Info\n");
-  printfQuda("=====================\n");
-  if(useTSM){
-    printfQuda(" Will perform the Truncated Solver method using the following parameters:\n");
-    printfQuda("  -N_HP = %d\n",TSM_NHP);
-    printfQuda("  -N_LP = %d\n",TSM_NLP);
-    if (TSM_maxiter == 0) printfQuda("  -CG stopping criterion is: tol = %e\n",TSM_tol);
-    else printfQuda("  -CG stopping criterion is: max-iter = %ld\n",TSM_maxiter);
-    printfQuda("  -Will dump every %d high-precision noise vectors, thus %d times\n",TSM_NdumpHP,TSM_NprintHP);
-    printfQuda("  -Will dump every %d low-precision noise vectors , thus %d times\n",TSM_NdumpLP,TSM_NprintLP);
-  }
-  else{
-    printfQuda(" Will not perform the Truncated Solver method\n");
-    printfQuda(" No. of noise vectors: %d\n",Nstoch);
-    printfQuda(" Will dump every %d noise vectors, thus %d times\n",Ndump,Nprint);
-  }
-  printfQuda(" The seed is: %ld\n",seed);
-  printfQuda(" The conf trajectory is: %04d\n",loopInfo.traj);
-  printfQuda(" Will produce the loop for %d Momentum Combinations\n",loopInfo.Nmoms);
-  printfQuda(" The loop file format is %s\n", (LoopFileFormat == ASCII_FORM) ? "ASCII" : "HDF5");
-  printfQuda(" The loop base name is %s\n",loopInfo.loop_fname);
-  printfQuda(" Will perform the loop for the following %d numbers of eigenvalues:",loopInfo.nSteps_defl);
-  for(int s=0;s<loopInfo.nSteps_defl;s++){
-    printfQuda("  %d",loopInfo.deflStep[s]);
-  }
-  if(info.source_type==RANDOM) printfQuda(" Will use RANDOM stochastic sources\n");
-  else if (info.source_type==UNITY) printfQuda(" Will use UNITY stochastic sources\n");
-  printfQuda("=====================\n\n");
-  
-  bool exact_part = true;
-  bool stoch_part = false;
-
-  bool LowPrecSum = true;
-  bool HighPrecSum = false;
-
-  //======================================================================//
-  //================ M E M O R Y   A L L O C A T I O N ===================// 
-  //======================================================================//
-
-  //- Allocate memory for accumulation buffers
-  void *std_uloc[loopInfo.nSteps_defl];
-  void *gen_uloc[loopInfo.nSteps_defl];
-  void *tmp_loop;
-
-  void **std_oneD[loopInfo.nSteps_defl];
-  void **gen_oneD[loopInfo.nSteps_defl];
-  void **std_csvC[loopInfo.nSteps_defl];
-  void **gen_csvC[loopInfo.nSteps_defl];
-
-  for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){  
-    //- ultra-local loops
-    if((cudaHostAlloc(&(std_uloc[dstep]), 
-		      sizeof(double)*2*16*GK_localVolume, 
-		      cudaHostAllocMapped)) != cudaSuccess)
-      errorQuda("%s: Error allocating memory std_uloc[%d]\n",fname,dstep);
-    if((cudaHostAlloc(&(gen_uloc[dstep]), 
-		      sizeof(double)*2*16*GK_localVolume, 
-		      cudaHostAllocMapped)) != cudaSuccess)
-      errorQuda("%s: Error allocating memory gen_uloc[%d]\n",fname,dstep);
-    if((cudaHostAlloc(&tmp_loop,          
-		      sizeof(double)*2*16*GK_localVolume, 
-		      cudaHostAllocMapped)) != cudaSuccess)
-      errorQuda("%s: Error allocating memory tmp_loop\n",fname);
-    
-    cudaMemset(std_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);
-    cudaMemset(gen_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);
-    cudaMemset(tmp_loop       , 0, sizeof(double)*2*16*GK_localVolume);
-    cudaDeviceSynchronize();
-
-    //- one-Derivative and conserved current loops
-    std_oneD[dstep] = (void**) malloc(sizeof(double*)*4);
-    gen_oneD[dstep] = (void**) malloc(sizeof(double*)*4);
-    std_csvC[dstep] = (void**) malloc(sizeof(double*)*4);
-    gen_csvC[dstep] = (void**) malloc(sizeof(double*)*4);
-    
-    if(std_oneD[dstep] == NULL) 
-      errorQuda("%s: Error allocating memory std_oneD[%d]\n",fname,dstep);
-    if(gen_oneD[dstep] == NULL) 
-      errorQuda("%s: Error allocating memory gen_oneD[%d]\n",fname,dstep);
-    if(std_csvC[dstep] == NULL) 
-      errorQuda("%s: Error allocating memory std_csvC[%d]\n",fname,dstep);
-    if(gen_csvC[dstep] == NULL) 
-      errorQuda("%s: Error allocating memory gen_csvC[%d]\n",fname,dstep);
-    cudaDeviceSynchronize();
-    
-    for(int mu = 0; mu < 4 ; mu++){
-      if((cudaHostAlloc(&(std_oneD[dstep][mu]), 
-			sizeof(double)*2*16*GK_localVolume, 
-			cudaHostAllocMapped)) != cudaSuccess)
-	errorQuda("%s: Error allocating memory std_oneD[%d][%d]\n",
-		  fname,dstep,mu);
-      if((cudaHostAlloc(&(gen_oneD[dstep][mu]), 
-			sizeof(double)*2*16*GK_localVolume, 
-			cudaHostAllocMapped)) != cudaSuccess)
-	errorQuda("%s: Error allocating memory gen_oneD[%d][%d]\n",
-		  fname,dstep,mu);
-      if((cudaHostAlloc(&(std_csvC[dstep][mu]), 
-			sizeof(double)*2*16*GK_localVolume, 
-			cudaHostAllocMapped)) != cudaSuccess)
-	errorQuda("%s: Error allocating memory std_csvC[%d][%d]\n",
-		  fname,dstep,mu);
-      if((cudaHostAlloc(&(gen_csvC[dstep][mu]), 
-			sizeof(double)*2*16*GK_localVolume, 
-			cudaHostAllocMapped)) != cudaSuccess)
-	errorQuda("%s: Error allocating memory gen_csvC[%d][%d]\n",
-		  fname,dstep,mu);
-      
-      cudaMemset(std_oneD[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
-      cudaMemset(gen_oneD[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
-      cudaMemset(std_csvC[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
-      cudaMemset(gen_csvC[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
-    }
-    cudaDeviceSynchronize();
-  }//-dstep
-  //--------------------------------------
-  
-  //-Allocate memory for the write buffers
-  int Nprt = ( useTSM ? TSM_NprintLP : Nprint );
-
-  double *buf_std_uloc[loopInfo.nSteps_defl];
-  double *buf_gen_uloc[loopInfo.nSteps_defl];
-  double **buf_std_oneD[loopInfo.nSteps_defl];
-  double **buf_gen_oneD[loopInfo.nSteps_defl];
-  double **buf_std_csvC[loopInfo.nSteps_defl];
-  double **buf_gen_csvC[loopInfo.nSteps_defl];
-
-  for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
-
-  buf_std_uloc[dstep] = 
-    (double*)malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
-  buf_gen_uloc[dstep] = 
-    (double*)malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
-
-    buf_std_oneD[dstep] = (double**) malloc(sizeof(double*)*4);
-    buf_gen_oneD[dstep] = (double**) malloc(sizeof(double*)*4);  
-    buf_std_csvC[dstep] = (double**) malloc(sizeof(double*)*4);
-    buf_gen_csvC[dstep] = (double**) malloc(sizeof(double*)*4);
-    
-    if( buf_std_uloc[dstep] == NULL ) 
-      errorQuda("Allocation of buffer buf_std_uloc[%d] failed.\n",dstep);
-    if( buf_gen_uloc[dstep] == NULL ) 
-      errorQuda("Allocation of buffer buf_gen_uloc[%d] failed.\n",dstep);
-    
-    if( buf_std_oneD[dstep] == NULL ) 
-      errorQuda("Allocation of buffer buf_std_oneD[%d] failed.\n",dstep);
-    if( buf_gen_oneD[dstep] == NULL ) 
-      errorQuda("Allocation of buffer buf_gen_oneD[%d] failed.\n",dstep);
-    if( buf_std_csvC[dstep] == NULL ) 
-      errorQuda("Allocation of buffer buf_std_csvC[%d] failed.\n",dstep);
-    if( buf_gen_csvC[dstep] == NULL ) 
-      errorQuda("Allocation of buffer buf_gen_csvC[%d] failed.\n",dstep);
-    
-    for(int mu = 0; mu < 4 ; mu++){
-      buf_std_oneD[dstep][mu] = 
-	(double*) malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
-      buf_gen_oneD[dstep][mu] = 
-	(double*) malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
-      buf_std_csvC[dstep][mu] = 
-	(double*) malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
-      buf_gen_csvC[dstep][mu] = 
-	(double*) malloc(sizeof(double)*Nprt*2*16*Nmoms*GK_localL[3]);
-      
-     if( buf_std_oneD[dstep][mu] == NULL ) 
-       errorQuda("Allocation of buffer buf_std_oneD[%d][%d] failed.\n",
-		 dstep,mu);
-     if( buf_gen_oneD[dstep][mu] == NULL ) 
-       errorQuda("Allocation of buffer buf_gen_oneD[%d][%d] failed.\n",
-		 dstep,mu);
-     if( buf_std_csvC[dstep][mu] == NULL ) 
-       errorQuda("Allocation of buffer buf_std_csvC[%d][%d] failed.\n",
-		 dstep,mu);
-     if( buf_gen_csvC[dstep][mu] == NULL ) 
-       errorQuda("Allocation of buffer buf_gen_csvC[%d][%d] failed.\n",
-		 dstep,mu);
-    }
-  }
-  
-  //- Allocate extra memory if using TSM
-  void *std_uloc_LP[loopInfo.nSteps_defl];
-  void *gen_uloc_LP[loopInfo.nSteps_defl];
-  void **std_oneD_LP[loopInfo.nSteps_defl];
-  void **gen_oneD_LP[loopInfo.nSteps_defl];
-  void **std_csvC_LP[loopInfo.nSteps_defl];
-  void **gen_csvC_LP[loopInfo.nSteps_defl];
-
-  double *buf_std_uloc_LP[loopInfo.nSteps_defl];
-  double *buf_gen_uloc_LP[loopInfo.nSteps_defl];
-  double *buf_std_uloc_HP[loopInfo.nSteps_defl];
-  double *buf_gen_uloc_HP[loopInfo.nSteps_defl];
-
-  double **buf_std_oneD_LP[loopInfo.nSteps_defl];
-  double **buf_gen_oneD_LP[loopInfo.nSteps_defl];
-  double **buf_std_csvC_LP[loopInfo.nSteps_defl];
-  double **buf_gen_csvC_LP[loopInfo.nSteps_defl];
-  double **buf_std_oneD_HP[loopInfo.nSteps_defl];
-  double **buf_gen_oneD_HP[loopInfo.nSteps_defl]; 
-  double **buf_std_csvC_HP[loopInfo.nSteps_defl]; 
-  double **buf_gen_csvC_HP[loopInfo.nSteps_defl];
-  
-  if(useTSM){
-    for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
-      //- low-precision accumulation buffers, ultra-local
-      if((cudaHostAlloc(&(std_uloc_LP[dstep]), 
-			sizeof(double)*2*16*GK_localVolume, 
-			cudaHostAllocMapped)) != cudaSuccess)
-	errorQuda("%s: Error allocating memory std_uloc_LP[%d]\n",
-		  fname,dstep);
-
-      if((cudaHostAlloc(&(gen_uloc_LP[dstep]), 
-			sizeof(double)*2*16*GK_localVolume, 
-			cudaHostAllocMapped)) != cudaSuccess)
-	errorQuda("%s: Error allocating memory gen_uloc_LP[%d]\n",
-		  fname,dstep);
-      
-      cudaMemset(std_uloc_LP[dstep], 0, sizeof(double)*2*16*GK_localVolume);
-      cudaMemset(gen_uloc_LP[dstep], 0, sizeof(double)*2*16*GK_localVolume);
-      cudaDeviceSynchronize();
-      
-      //- low-precision accumulation buffers, 
-      // one-Derivative and conserved current
-      std_oneD_LP[dstep] = (void**) malloc(4*sizeof(double*));
-      gen_oneD_LP[dstep] = (void**) malloc(4*sizeof(double*));
-      std_csvC_LP[dstep] = (void**) malloc(4*sizeof(double*));
-      gen_csvC_LP[dstep] = (void**) malloc(4*sizeof(double*));
-      
-      if(gen_oneD_LP[dstep] == NULL) 
-	errorQuda("%s: Error allocating memory gen_oneD_LP[%d]\n",
-		  fname,dstep);
-      if(std_oneD_LP[dstep] == NULL) 
-	errorQuda("%s: Error allocating memory std_oneD_LP[%d]\n",
-		  fname,dstep);
-      if(gen_csvC_LP[dstep] == NULL) 
-	errorQuda("%s: Error allocating memory gen_csvC_LP[%d]\n",
-		  fname,dstep);
-      if(std_csvC_LP[dstep] == NULL) 
-	errorQuda("%s: Error allocating memory std_csvC_LP[%d]\n",
-		  fname,dstep);
-      cudaDeviceSynchronize();
-      
-      for(int mu = 0; mu < 4 ; mu++){
-	if((cudaHostAlloc(&(std_oneD_LP[dstep][mu]), 
-			  sizeof(double)*2*16*GK_localVolume, 
-			  cudaHostAllocMapped)) != cudaSuccess)
-	  errorQuda("%s: Error allocating memory std_oneD_LP[%d][%d]\n",
-		    fname,dstep,mu);
-
-	if((cudaHostAlloc(&(gen_oneD_LP[dstep][mu]), 
-			  sizeof(double)*2*16*GK_localVolume, 
-			  cudaHostAllocMapped)) != cudaSuccess)
-	  errorQuda("%s: Error allocating memory gen_oneD_LP[%d][%d]\n",
-		    fname,dstep,mu);
-
-	if((cudaHostAlloc(&(std_csvC_LP[dstep][mu]), 
-			  sizeof(double)*2*16*GK_localVolume, 
-			  cudaHostAllocMapped)) != cudaSuccess)
-	  errorQuda("%s: Error allocating memory std_csvC_LP[%d][%d]\n",
-		    fname,dstep,mu);
-	
-	if((cudaHostAlloc(&(gen_csvC_LP[dstep][mu]), 
-			  sizeof(double)*2*16*GK_localVolume, 
-			  cudaHostAllocMapped)) != cudaSuccess)
-	  errorQuda("%s: Error allocating memory gen_csvC_LP[%d][%d]\n",
-		    fname,dstep,mu);    
-	
-	cudaMemset(std_oneD_LP[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);
-	cudaMemset(gen_oneD_LP[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);
-	cudaMemset(std_csvC_LP[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);
-	cudaMemset(gen_csvC_LP[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);
-      }
-      cudaDeviceSynchronize();
-      //------------------------------
-
-
-      //-write buffers for Low-precision loops      
-      buf_std_uloc_LP[dstep] = 
-	(double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-      buf_gen_uloc_LP[dstep] = 
-	(double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-
-      buf_std_oneD_LP[dstep] = (double**)malloc(4*sizeof(double*));
-      buf_gen_oneD_LP[dstep] = (double**)malloc(4*sizeof(double*));
-      buf_std_csvC_LP[dstep] = (double**)malloc(4*sizeof(double*));
-      buf_gen_csvC_LP[dstep] = (double**)malloc(4*sizeof(double*));
-
-      if( buf_std_uloc_LP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_std_uloc_LP[%d] failed.",dstep);
-      if( buf_gen_uloc_LP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_gen_uloc_LP[%d] failed.",dstep);
-      
-      if( buf_std_oneD_LP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_std_oneD_LP[%d] failed.",dstep);
-      if( buf_gen_oneD_LP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_std_oneD_LP[%d] failed.",dstep);
-      if( buf_std_csvC_LP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_std_oneD_LP[%d] failed.",dstep);
-      if( buf_gen_csvC_LP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_std_oneD_LP[%d] failed.",dstep);
-
-      for(int mu = 0; mu < 4 ; mu++){
-
-      buf_std_oneD_LP[dstep][mu] = 
-        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-      buf_gen_oneD_LP[dstep][mu] = 
-        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-      buf_std_csvC_LP[dstep][mu] = 
-        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-      buf_gen_csvC_LP[dstep][mu] = 
-        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-      
-      if(buf_std_oneD_LP[dstep][mu] == NULL) 
-	errorQuda("Allocation of buffer buf_std_oneD_LP[%d][%d] failed.",
-		  dstep,mu);
-      if(buf_gen_oneD_LP[dstep][mu] == NULL) 
-	errorQuda("Allocation of buffer buf_std_oneD_LP[%d][%d] failed.",
-		  dstep,mu);
-      if(buf_std_csvC_LP[dstep][mu] == NULL) 
-	errorQuda("Allocation of buffer buf_std_oneD_LP[%d][%d] failed.",
-		   dstep,mu);
-      if(buf_gen_csvC_LP[dstep][mu] == NULL) 
-	errorQuda("Allocation of buffer buf_std_oneD_LP[%d][%d] failed.",
-		   dstep,mu);
-      }
-      
-      //-write buffers for High-precision loops
-      buf_std_uloc_HP[dstep] = 
-	(double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-      buf_gen_uloc_HP[dstep] = 
-	(double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-
-      buf_std_oneD_HP[dstep] = (double**)malloc(4*sizeof(double*));
-      buf_gen_oneD_HP[dstep] = (double**)malloc(4*sizeof(double*));
-      buf_std_csvC_HP[dstep] = (double**)malloc(4*sizeof(double*));
-      buf_gen_csvC_HP[dstep] = (double**)malloc(4*sizeof(double*));
-
-      if( buf_std_uloc_HP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_std_uloc_HP[%d] failed.",dstep);
-      if( buf_gen_uloc_HP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_gen_uloc_HP[%d] failed.",dstep);
-      
-      if( buf_std_oneD_HP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_std_oneD_HP[%d] failed.",dstep);
-      if( buf_gen_oneD_HP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_std_oneD_HP[%d] failed.",dstep);
-      if( buf_std_csvC_HP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_std_oneD_HP[%d] failed.",dstep);
-      if( buf_gen_csvC_HP[dstep] == NULL ) 
-	errorQuda("Allocation of buffer buf_std_oneD_HP[%d] failed.",dstep);
-
-      for(int mu = 0; mu < 4 ; mu++){
-
-      buf_std_oneD_HP[dstep][mu] = 
-        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-      buf_gen_oneD_HP[dstep][mu] = 
-        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-      buf_std_csvC_HP[dstep][mu] = 
-        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-      buf_gen_csvC_HP[dstep][mu] = 
-        (double*)malloc(TSM_NprintHP*2*16*Nmoms*GK_localL[3]*sizeof(double));
-      
-      if(buf_std_oneD_HP[dstep][mu] == NULL) 
-	errorQuda("Allocation of buffer buf_std_oneD_HP[%d][%d] failed.",
-		  dstep,mu);
-      if(buf_gen_oneD_HP[dstep][mu] == NULL) 
-	errorQuda("Allocation of buffer buf_std_oneD_HP[%d][%d] failed.",
-		  dstep,mu);
-      if(buf_std_csvC_HP[dstep][mu] == NULL) 
-	errorQuda("Allocation of buffer buf_std_oneD_HP[%d][%d] failed.",
-		   dstep,mu);
-      if(buf_gen_csvC_HP[dstep][mu] == NULL) 
-	errorQuda("Allocation of buffer buf_std_oneD_HP[%d][%d] failed.",
-		   dstep,mu);
-      }
-
-    }//-dsetp
-  }//-if useTSM
-  
-  //-Allocate the momenta
-  int **mom,**momQsq;
-  long int SplV = GK_totalL[0]*GK_totalL[1]*GK_totalL[2];
-  mom =    (int**) malloc(sizeof(int*)*SplV);
-  momQsq = (int**) malloc(sizeof(int*)*Nmoms);
-  if(mom    == NULL) errorQuda("Error in allocating mom\n");
-  if(momQsq == NULL) errorQuda("Error in allocating momQsq\n");
-  
-  for(int ip=0; ip<SplV; ip++) {
-    mom[ip] = (int*) malloc(sizeof(int)*3);
-    if(mom[ip] == NULL) errorQuda("Error in allocating mom[%d]\n",ip);
-  }
-  for(int ip=0; ip<Nmoms; ip++) {
-    momQsq[ip] = (int *) malloc(sizeof(int)*3);
-    if(momQsq[ip] == NULL) errorQuda("Error in allocating momQsq[%d]\n",ip);
-  }
-  createLoopMomenta(mom,momQsq,info.Q_sq,Nmoms);
-  printfQuda("Momenta created\n");
-
-  //======================================================================//
-  //========== E X A C T   P R O B L E M   C O N S T R U C T =============// 
-  //======================================================================//
-
-  // QKXTM: DMH Here the low modes of the normal M^{\dagger}M 
-  //        operator are constructed. The correlation function
-  //        values are calculated at every Nth deflation step:
-  //        Nth = loopInfo.deflStep[s]
-  
-  printfQuda("\n ### Exact part calculation ###\n");
-
-  int NeV_Full = arpackInfo.nEv;  
-  
-  //Create object to store and calculate eigenpairs
-  QKXTM_Deflation_Kepler<double> *deflation = 
-    new QKXTM_Deflation_Kepler<double>(param,arpackInfo);
-  deflation->printInfo();
-  
-  //- Calculate the eigenVectors
-  t1 = MPI_Wtime(); 
-  deflation->eigenSolver();
-  t2 = MPI_Wtime();
-  printfQuda("%s TIME REPORT:",fname);
-  printfQuda("Full Operator EigenVector Calculation: %f sec\n",t2-t1);
-
-  deflation->MapEvenOddToFull();
-
-  //- Calculate the exact part of the loop
-  int iPrint = 0;
-  int s = 0;
-  for(int n=0;n<NeV_Full;n++){
-    t1 = MPI_Wtime();
-    deflation->Loop_w_One_Der_FullOp_Exact(n, EvInvParam, 
-					   gen_uloc[0], std_uloc[0], 
-					   gen_oneD[0], std_oneD[0], 
-					   gen_csvC[0], std_csvC[0]);
-    t2 = MPI_Wtime();
-    printfQuda("TIME_REPORT: Exact part for EV %d done in: %f sec\n",
-	       n+1,t2-t1);
-    
-    if( (n+1)==loopInfo.deflStep[s] ){     
-      if(GK_nProc[2]==1){      
-	doCudaFFT_v2<double>(std_uloc[0], tmp_loop); // Scalar
-	copyLoopToWriteBuf(buf_std_uloc[0], tmp_loop,
-			   iPrint, info.Q_sq, Nmoms,mom);
-	doCudaFFT_v2<double>(gen_uloc[0], tmp_loop); // dOp
-	copyLoopToWriteBuf(buf_gen_uloc[0], tmp_loop, 
-			   iPrint, info.Q_sq, Nmoms,mom);
-	
-	for(int mu = 0 ; mu < 4 ; mu++){
-	  doCudaFFT_v2<double>(std_oneD[0][mu], tmp_loop); // Loops
-	  copyLoopToWriteBuf(buf_std_oneD[0][mu], tmp_loop,
-			     iPrint, info.Q_sq, Nmoms,mom);
-	  doCudaFFT_v2<double>(std_csvC[0][mu], tmp_loop); // LoopsCv
-	  copyLoopToWriteBuf(buf_std_csvC[0][mu], tmp_loop, 
-			     iPrint, info.Q_sq, Nmoms, mom);
-	  
-	  doCudaFFT_v2<double>(gen_oneD[0][mu], tmp_loop); // LpsDw
-	  copyLoopToWriteBuf(buf_gen_oneD[0][mu], tmp_loop, 
-			     iPrint, info.Q_sq, Nmoms, mom);
-	  doCudaFFT_v2<double>(gen_csvC[0][mu], tmp_loop); // LpsDwCv
-	  copyLoopToWriteBuf(buf_gen_csvC[0][mu], tmp_loop, 
-			     iPrint, info.Q_sq, Nmoms, mom);
-	}
-	printfQuda("Exact part of Loops for NeV = %d copied to write buffers\n",n+1);
-      }
-      else if(GK_nProc[2]>1){
-	t1 = MPI_Wtime();
-	performFFT<double>(buf_std_uloc[0], std_uloc[0], 
-			   iPrint, Nmoms, momQsq);
-	performFFT<double>(buf_gen_uloc[0], gen_uloc[0], 
-			   iPrint, Nmoms, momQsq);
-	
-	for(int mu=0;mu<4;mu++){
-	  performFFT<double>(buf_std_oneD[0][mu], std_oneD[0][mu], 
-			     iPrint, Nmoms, momQsq);
-	  performFFT<double>(buf_std_csvC[0][mu], std_csvC[0][mu], 
-			     iPrint, Nmoms, momQsq);
-	  performFFT<double>(buf_gen_oneD[0][mu], gen_oneD[0][mu], 
-			     iPrint, Nmoms, momQsq);
-	  performFFT<double>(buf_gen_csvC[0][mu], gen_csvC[0][mu], 
-			     iPrint, Nmoms, momQsq);
-	}
-	t2 = MPI_Wtime();
-	printfQuda("TIME_REPORT: FFT and copying to Write Buffers is %f sec\n",t2-t1);
-      }
-
-      //================================================================//
-      //=============== D U M P   E X A C T   D A T A  =================// 
-      //================================================================//
-
-      //-Write the exact part of the loop
-      sprintf(loop_exact_fname,"%s_exact_NeV%d",loopInfo.loop_fname,n+1);
-      if(LoopFileFormat==ASCII_FORM){ // Write the loops in ASCII format
-	// Scalar
-	writeLoops_ASCII(buf_std_uloc[0], loop_exact_fname, 
-			 loopInfo, momQsq, 0, 0, exact_part, false, false);
-	// dOp
-	writeLoops_ASCII(buf_gen_uloc[0], loop_exact_fname, 
-			 loopInfo, momQsq, 1, 0, exact_part, false ,false);
-	for(int mu = 0 ; mu < 4 ; mu++){
-	  // Loops
-	  writeLoops_ASCII(buf_std_oneD[0][mu], loop_exact_fname, 
-			   loopInfo, momQsq, 2, mu, exact_part,false,false);
-	  // LoopsCv 
-	  writeLoops_ASCII(buf_std_csvC[0][mu], loop_exact_fname, 
-			   loopInfo, momQsq, 3, mu, exact_part,false,false);
-	  // LpsDw
-	  writeLoops_ASCII(buf_gen_oneD[0][mu], loop_exact_fname, 
-			   loopInfo, momQsq, 4, mu, exact_part,false,false);
-	  // LpsDwCv 
-	  writeLoops_ASCII(buf_gen_csvC[0][mu], loop_exact_fname, 
-			   loopInfo, momQsq, 5, mu, exact_part,false,false); 
-	}
-      }
-      else if(LoopFileFormat==HDF5_FORM){
-	// Write the loops in HDF5 format
-	writeLoops_HDF5(buf_std_uloc[0], buf_gen_uloc[0], 
-			buf_std_oneD[0], buf_std_csvC[0], 
-			buf_gen_oneD[0], buf_gen_csvC[0], 
-			loop_exact_fname, loopInfo, 
-			momQsq, exact_part, false, false);
-      }
-      
-      printfQuda("Writing the Exact part of the loops for NeV = %d completed.\n",n+1);
-      s++;
-    }//-if
-  }//-for NeV_Full
-  
-  printfQuda("\n ### Exact part calculation Done ###\n");
-
-  //=====================================================================//
-  //======  S T O C H A S T I C   P R O B L E M   C O N S T R U C T =====//
-  //=====================================================================//
-
-  //QKXTM: DMH Here we calculate the contribution to the All-to-All
-  //       propagator from stochastic sources. In previous versions
-  //       of this code, deflation was used to accelerate the inversions
-  //       using either a deflation operator from the exact part with a 
-  //       normal (M^+M \phi = M^+ \eta) solve type, or exact deflation 
-  //       and an extra Even/Odd preconditioned deflation step on the 
-  //       remainder.
-  //       Due to the direct solve limitation of MG, we can longer use
-  //       the exact part to accelerate the problem execution. We
-  //       therefore simply solve for the stochastic source using MG,
-  //       then project out the exact contribution from the solution.
-
-  printfQuda("\n ### Stochastic part calculation ###\n\n");
-
-  cudaGaugeField *cudaGauge = checkGauge(param);
-  checkInvertParam(param);
-
-  QKXTM_Gauge_Kepler<double> *K_gauge = 
-    new QKXTM_Gauge_Kepler<double>(BOTH,GAUGE);
-  K_gauge->packGauge(gaugeToPlaquette);
-  K_gauge->loadGauge();
-  K_gauge->calculatePlaq();
-
-  // QKXTM: DMH Calculation should default to these settings.
-  printfQuda("%s: Will solve the stochastic part using Multigrid.\n",fname);
-
-  // QKXTM: DMH This is a fairly arbitrary setting in terms of
-  //        solver performance. 
-  bool flag_eo = false;
-
-  // QKXTM: DMH EO preconditioned solves offer x2
-  //        speed up, we should always use it.
-  bool pc_solve = true;
-
-  // QKXTM: DMH we MUST construct the full solution spinor
-  //        in order to properly project out the exact part.
-  bool pc_solution = false;
-
-  bool mat_solution = 
-    (param->solution_type == QUDA_MAT_SOLUTION) || 
-    (param->solution_type == QUDA_MATPC_SOLUTION);
-  // QKXTM: DMH MG can only use DIRECT solves.
-  bool direct_solve = true;
-
-  param->spinorGiB = cudaGauge->VolumeCB() * spinorSiteSize;
-  if (!pc_solve) param->spinorGiB *= 2;
-  param->spinorGiB *= (param->cuda_prec == QUDA_DOUBLE_PRECISION ? sizeof(double) : sizeof(float));
-  if (param->preserve_source == QUDA_PRESERVE_SOURCE_NO) {
-    param->spinorGiB *= (param->inv_type == QUDA_CG_INVERTER ? 5 : 7)/(double)(1<<30);
-  } else {
-    param->spinorGiB *= (param->inv_type == QUDA_CG_INVERTER ? 8 : 9)/(double)(1<<30);
-  }
-  param->secs = 0;
-  param->gflops = 0;
-  param->iter = 0;
-
-  Dirac *d = NULL;
-  Dirac *dSloppy = NULL;
-  Dirac *dPre = NULL;
-  createDirac(d, dSloppy, dPre, *param, pc_solve);
-  Dirac &dirac = *d;
-  Dirac &diracSloppy = *dSloppy;
-  Dirac &diracPre = *dPre;
-  profileInvert.TPSTART(QUDA_PROFILE_H2D);
-
-  ColorSpinorField *b = NULL;
-  ColorSpinorField *x = NULL;
-  ColorSpinorField *in = NULL;
-  ColorSpinorField *out = NULL;
-  ColorSpinorField *sol    = NULL;
-  ColorSpinorField *sol_LP = NULL;
-  ColorSpinorField *tmp3 = NULL;
-  ColorSpinorField *tmp4 = NULL;
-  ColorSpinorField *x_LP   = NULL;
-  ColorSpinorField *out_LP = NULL;
-
-  const int *X = cudaGauge->X();
-
-  void *input_vector = malloc(X[0]*X[1]*X[2]*X[3]*
-			      spinorSiteSize*sizeof(double));
-  void *output_vector = malloc(X[0]*X[1]*X[2]*X[3]*
-			       spinorSiteSize*sizeof(double));
-
-  memset(input_vector,0,X[0]*X[1]*X[2]*X[3]*spinorSiteSize*sizeof(double));
-  memset(output_vector,0,X[0]*X[1]*X[2]*X[3]*spinorSiteSize*sizeof(double));
-
-  // wrap CPU host side pointers
-  ColorSpinorParam cpuParam(input_vector, *param, X, 
-			    pc_solution, param->input_location);
-  ColorSpinorField *h_b = ColorSpinorField::Create(cpuParam);
-
-  cpuParam.v = output_vector;
-  cpuParam.location = param->output_location;
-  ColorSpinorField *h_x = ColorSpinorField::Create(cpuParam);
-
-  //Zero out the spinors
-  ColorSpinorParam cudaParam(cpuParam, *param);
-  cudaParam.create = QUDA_ZERO_FIELD_CREATE;
-  b    = new cudaColorSpinorField(*h_b, cudaParam);
-  x    = new cudaColorSpinorField(cudaParam);
-  tmp3 = new cudaColorSpinorField(cudaParam);
-  tmp4 = new cudaColorSpinorField(cudaParam);
-  if(useTSM) x_LP = new cudaColorSpinorField(cudaParam);
-  profileInvert.TPSTOP(QUDA_PROFILE_H2D);
-  setTuning(param->tune);
-
-  QKXTM_Vector_Kepler<double> *K_vector = 
-    new QKXTM_Vector_Kepler<double>(BOTH,VECTOR);
-  QKXTM_Vector_Kepler<double> *K_vecdef = 
-    new QKXTM_Vector_Kepler<double>(BOTH,VECTOR);
-
-  //Solver operators
-  DiracM m(dirac), mSloppy(diracSloppy), mPre(diracPre);
-
-  //-Set Randon Number Generator
-  gsl_rng *rNum = gsl_rng_alloc(gsl_rng_ranlux);
-  gsl_rng_set(rNum, seed + comm_rank()*seed);
-
-  //-Define the accumulation-sum limits
-  int Nrun;
-  int Nd;
-  char *msg_str;
-  if(useTSM){
-    Nrun = TSM_NLP;
-    Nd = TSM_NdumpLP;
-    asprintf(&msg_str,"NLP");
-  }
-  else{
-    Nrun = Nstoch;
-    Nd = Ndump;
-    asprintf(&msg_str,"Stoch.");
-  }
-
-  //- Prepare the accumulation buffers for the stochastic part
-  cudaMemset(tmp_loop, 0, sizeof(double)*2*16*GK_localVolume);
-  for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
-    cudaMemset(std_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);
-    cudaMemset(gen_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);
-    
-    for(int mu = 0; mu < 4 ; mu++){
-      cudaMemset(std_oneD[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
-      cudaMemset(gen_oneD[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
-      cudaMemset(std_csvC[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
-      cudaMemset(gen_csvC[dstep][mu], 0, sizeof(double)*2*16*GK_localVolume);
-    }
-    cudaDeviceSynchronize();
-  }
-  //----------------
-  
-  int nDeflSteps;  
-  iPrint = -1;
-  for(int is = 0 ; is < Nrun ; is++){
-    t3 = MPI_Wtime();
-    t1 = MPI_Wtime();
-    memset(input_vector,0,X[0]*X[1]*X[2]*X[3]*spinorSiteSize*sizeof(double));
-    getStochasticRandomSource<double>(input_vector,rNum,info.source_type);
-
-    t2 = MPI_Wtime();
-    printfQuda("TIME_REPORT: %s %04d - Source creation: %f sec\n",
-	       msg_str,is+1,t2-t1);
-
-    K_vector->packVector((double*) input_vector);
-    K_vector->loadVector();
-    K_vector->uploadToCuda(b,flag_eo);
-    // in -> b, out -> x, for parity singlets
-    dirac.prepare(in,out,*x,*b,param->solution_type); 
-
-    //QKXTM: DMH No source preparation is required
-      
-    t1 = MPI_Wtime();
-    nDeflSteps = loopInfo.nSteps_defl;
-      
-    //If we are using the TSM, we need the LP
-    //solve for bias estimation. 
-    if(useTSM) {
-      //LP solve
-      double orig_tol = param->tol;
-      long int orig_maxiter = param->maxiter;
-      // Set the low-precision criterion
-      if(TSM_maxiter==0) param->tol = TSM_tol;
-      else if(TSM_tol==0) param->maxiter = TSM_maxiter;  
-      
-      // Create the low-precision solver
-      SolverParam solverParam_LP(*param);
-      Solver *solve_LP = Solver::create(solverParam_LP, m, mSloppy, 
-					mPre, profileInvert);
-      //LP solve
-      (*solve_LP)(*out,*in);
-      delete solve_LP;
-      
-      // Revert to the original, high-precision values
-      if(TSM_maxiter==0) param->tol = orig_tol;           
-      else if(TSM_tol==0) param->maxiter = orig_maxiter;
-    }
-    //Else, just do the HP solve.
-    else {
-      //HP solve
-      SolverParam solverParam(*param);
-      Solver *solve = Solver::create(solverParam, m, mSloppy, 
-				     mPre, profileInvert);
-      (*solve)(*out,*in);
-      delete solve;
-    }
-    
-    dirac.reconstruct(*x,*b,param->solution_type);
-    
-    sol = new cudaColorSpinorField(*x);    
-
-    for(int dstep=0;dstep<nDeflSteps;dstep++){
-      int NeV_defl = loopInfo.deflStep[dstep];
-      printfQuda("# Performing contractions for NeV = %d\n",NeV_defl);
-      
-      t1 = MPI_Wtime();	
-      K_vector->downloadFromCuda(sol,flag_eo);
-      K_vector->download();
-      
-      // Solution is projected and put into x, x <- (1-UU^dag) x
-      deflation->projectVector(*K_vecdef,*K_vector,is+1,NeV_defl);
-      K_vecdef->uploadToCuda(x,flag_eo);              
-      
-      t2 = MPI_Wtime();
-      printfQuda("TIME_REPORT: %s %04d - Solution projection: %f sec\n",
-		 msg_str,is+1,t2-t1);
-      
-      
-      t1 = MPI_Wtime();
-      oneEndTrick_w_One_Der<double>(*x, *tmp3, *tmp4, param, 
-				    gen_uloc[dstep], std_uloc[dstep], 
-				    gen_oneD[dstep], std_oneD[dstep], 
-				    gen_csvC[dstep], std_csvC[dstep]);
-      t2 = MPI_Wtime();
-      printfQuda("TIME_REPORT: %s %04d - Contractions: %f sec\n",
-		 msg_str,is+1,t2-t1);
-      
-      t4 = MPI_Wtime();
-      printfQuda("### TIME_REPORT: %s %04d - Finished in %f sec\n",
-		 msg_str,is+1,t4-t3);      
-      
-      if( (is+1)%Nd == 0){
-	if(dstep==0) iPrint++;
-	t1 = MPI_Wtime();
-	if(GK_nProc[2]==1){      
-	  doCudaFFT_v2<double>(std_uloc[dstep], tmp_loop); // Scalar
-	  copyLoopToWriteBuf(buf_std_uloc[dstep], tmp_loop, 
-			     iPrint, info.Q_sq, Nmoms, mom);
-	  doCudaFFT_v2<double>(gen_uloc[dstep], tmp_loop); // dOp
-	  copyLoopToWriteBuf(buf_gen_uloc[dstep], tmp_loop, 
-			     iPrint, info.Q_sq, Nmoms, mom);
-	    
-	  for(int mu = 0 ; mu < 4 ; mu++){
-	    doCudaFFT_v2<double>(std_oneD[dstep][mu], tmp_loop); // Loops
-	    copyLoopToWriteBuf(buf_std_oneD[dstep][mu], tmp_loop, 
-			       iPrint, info.Q_sq, Nmoms, mom);
-	    doCudaFFT_v2<double>(std_csvC[dstep][mu], tmp_loop); // LoopsCv
-	    copyLoopToWriteBuf(buf_std_csvC[dstep][mu], tmp_loop, 
-			       iPrint, info.Q_sq, Nmoms, mom);	      
-	    doCudaFFT_v2<double>(gen_oneD[dstep][mu],tmp_loop); // LpsDw
-	    copyLoopToWriteBuf(buf_gen_oneD[dstep][mu], tmp_loop, 
-			       iPrint, info.Q_sq, Nmoms, mom);
-	    doCudaFFT_v2<double>(gen_csvC[dstep][mu], tmp_loop); // LpsDwCv
-	    copyLoopToWriteBuf(buf_gen_csvC[dstep][mu], tmp_loop, 
-			       iPrint, info.Q_sq, Nmoms, mom);
-	  }
-	}
-	else if(GK_nProc[2]>1){
-	  performFFT<double>(buf_std_uloc[dstep], std_uloc[dstep], 
-			     iPrint, Nmoms, momQsq);
-	  performFFT<double>(buf_gen_uloc[dstep], gen_uloc[dstep], 
-			     iPrint, Nmoms, momQsq);
-	    
-	  for(int mu=0;mu<4;mu++){
-	    performFFT<double>(buf_std_oneD[dstep][mu], std_oneD[dstep][mu],
-			       iPrint, Nmoms, momQsq);
-	    performFFT<double>(buf_std_csvC[dstep][mu], std_csvC[dstep][mu],
-			       iPrint, Nmoms, momQsq);
-	    performFFT<double>(buf_gen_oneD[dstep][mu], gen_oneD[dstep][mu],
-			       iPrint, Nmoms, momQsq);
-	    performFFT<double>(buf_gen_csvC[dstep][mu], gen_csvC[dstep][mu],
-			       iPrint, Nmoms, momQsq);
-	  }
-	}
-	t2 = MPI_Wtime();
-	printfQuda("Loops for %s = %04d FFT'ed and copied to write buffers in %f sec\n",msg_str,is+1,t2-t1);
-      }//-if (is+1)
-    }//-deflation steps
-
-    delete sol;
-  }//-Nstoch
-
-  //======================================================================//
-  //================ D U M P   D A T A   A T   Nth EV ====================// 
-  //======================================================================//
-
-  //-Write the stochastic part of the loops
-  for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
-    int NeV_defl = loopInfo.deflStep[dstep];
-
-    t1 = MPI_Wtime();
-    sprintf(loop_stoch_fname,"%s_stoch%sNeV%d",
-	    loopInfo.loop_fname, useTSM ? "_TSM_" : "_", NeV_defl);
-    if(LoopFileFormat==ASCII_FORM){ 
-      // Write the loops in ASCII format
-      writeLoops_ASCII(buf_std_uloc[dstep], loop_stoch_fname, 
-		       loopInfo, momQsq, 0, 0, stoch_part, 
-		       useTSM, LowPrecSum); // Scalar
-      writeLoops_ASCII(buf_gen_uloc[dstep], loop_stoch_fname, 
-		       loopInfo, momQsq, 1, 0, stoch_part, 
-		       useTSM, LowPrecSum); // dOp
-      for(int mu = 0 ; mu < 4 ; mu++){
-	writeLoops_ASCII(buf_std_oneD[dstep][mu], loop_stoch_fname, 
-			 loopInfo, momQsq, 2, mu, stoch_part, 
-			 useTSM, LowPrecSum); // Loops
-	writeLoops_ASCII(buf_std_csvC[dstep][mu], loop_stoch_fname, 
-			 loopInfo, momQsq, 3, mu, stoch_part, 
-			 useTSM, LowPrecSum); // LoopsCv
-	writeLoops_ASCII(buf_gen_oneD[dstep][mu], loop_stoch_fname, 
-			 loopInfo, momQsq, 4, mu, stoch_part, 
-			 useTSM, LowPrecSum); // LpsDw
-	writeLoops_ASCII(buf_gen_csvC[dstep][mu], loop_stoch_fname, 
-			 loopInfo, momQsq, 5, mu, stoch_part, 
-			 useTSM, LowPrecSum); // LpsDwCv
-      }
-    }
-    else if(LoopFileFormat==HDF5_FORM){ 
-      // Write the loops in HDF5 format
-      writeLoops_HDF5(buf_std_uloc[dstep], buf_gen_uloc[dstep], 
-		      buf_std_oneD[dstep], buf_std_csvC[dstep], 
-		      buf_gen_oneD[dstep], buf_gen_csvC[dstep],
-		      loop_stoch_fname, loopInfo, momQsq, 
-		      stoch_part, useTSM, LowPrecSum);
-    }
-    t2 = MPI_Wtime();
-    printfQuda("Writing the Stochastic part of the loops for NeV = %d completed in %f sec.\n",NeV_defl,t2-t1);
-  }//-dstep
-
-
-  //- If using Truncated-Solver-Method, then proceed with
-  //- performing the loop calculation, for the low-precision and the 
-  //- high-precision inversions
-  if(useTSM){
-    //-Prepare the loops for the High- and Low-Precision
-    cudaMemset(tmp_loop, 0, sizeof(double)*2*16*GK_localVolume);
-    for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
-      cudaMemset(std_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);  
-      cudaMemset(std_uloc_LP[dstep], 0, sizeof(double)*2*16*GK_localVolume);
-      cudaMemset(gen_uloc[dstep], 0, sizeof(double)*2*16*GK_localVolume);  
-      cudaMemset(gen_uloc_LP[dstep], 0, sizeof(double)*2*16*GK_localVolume);
-      
-      for(int mu = 0; mu < 4 ; mu++){
-	cudaMemset(std_oneD[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume); 
-	cudaMemset(std_oneD_LP[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);
-	cudaMemset(gen_oneD[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);  
-	cudaMemset(gen_oneD_LP[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);
-	cudaMemset(std_csvC[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);  
-	cudaMemset(std_csvC_LP[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);
-	cudaMemset(gen_csvC[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);  
-	cudaMemset(gen_csvC_LP[dstep][mu], 0, 
-		   sizeof(double)*2*16*GK_localVolume);
-      }
-      cudaDeviceSynchronize();
-    }
-    //-------------------------------------------------
-    
-    printfQuda("\nWill Perform the HP and LP inversions\n\n");
-
-    Nrun = TSM_NHP;
-    Nd = TSM_NdumpHP;
-    iPrint = -1;
-    for(int is = 0 ; is < Nrun ; is++){
-      t3 = MPI_Wtime();
-      t1 = MPI_Wtime();
-      memset(input_vector,0,
-	     GK_localL[0]*
-	     GK_localL[1]*
-	     GK_localL[2]*
-	     GK_localL[3]*spinorSiteSize*sizeof(double));
-
-      getStochasticRandomSource<double>(input_vector,rNum,info.source_type);
-
-      t2 = MPI_Wtime();
-      printfQuda("TIME_REPORT: %s %04d - Source creation: %f sec\n",
-		 msg_str,is+1,t2-t1);
-      K_vector->packVector((double*) input_vector);
-      K_vector->loadVector();
-      K_vector->uploadToCuda(b,flag_eo);
-      
-      blas::zero(*out);
-      blas::zero(*out_LP);
-      
-      // in -> b, out -> x, for parity singlets
-      dirac.prepare(in,out   ,*x   ,*b,param->solution_type); 
-      dirac.prepare(in,out_LP,*x_LP,*b,param->solution_type);
-
-      t1 = MPI_Wtime();
-	
-      //HP solve
-      //-------------------------------------------------
-      SolverParam solverParam(*param);
-      Solver *solve = Solver::create(solverParam, m, mSloppy, mPre, 
-				     profileInvert);
-      (*solve)   (*out,*in);
-      delete solve;
-      dirac.reconstruct(*x,*b,param->solution_type);
-      //-------------------------------------------------
-      
-      
-      //LP solve
-      //-------------------------------------------------
-      double orig_tol = param->tol;
-      long int orig_maxiter = param->maxiter;
-      // Set the low-precision criterion
-      if(TSM_maxiter==0) param->tol = TSM_tol;
-      else if(TSM_tol==0) param->maxiter = TSM_maxiter;  
-      
-      // Create the low-precision solver
-      SolverParam solverParam_LP(*param);
-      Solver *solve_LP = Solver::create(solverParam_LP, m, mSloppy, 
-					mPre, profileInvert);
-      (*solve_LP)(*out_LP,*in);
-      delete solve_LP;
-      dirac.reconstruct(*x_LP,*b,param->solution_type);
-      
-      // Revert to the original, high-precision values
-      if(TSM_maxiter==0) param->tol = orig_tol;           
-      else if(TSM_tol==0) param->maxiter = orig_maxiter;      
-      //-------------------------------------------------
-      
-      sol    = new cudaColorSpinorField(*x);
-      sol_LP = new cudaColorSpinorField(*x_LP);
-      
-      for(int dstep=0;dstep<nDeflSteps;dstep++){
-	int NeV_defl = loopInfo.deflStep[dstep];
-	printfQuda("# Performing TSM contractions for NeV = %d\n",NeV_defl);
-	
-	t1 = MPI_Wtime();
-	K_vector->downloadFromCuda(sol,flag_eo);
-	K_vector->download();
-	deflation->projectVector(*K_vecdef,*K_vector,is+1,NeV_defl);
-	
-	// Solution is projected and put into x, x <- (1-UU^dag) x
-	K_vecdef->uploadToCuda(x,flag_eo);
-	t2 = MPI_Wtime();
-	printfQuda("TIME_REPORT: NHP %04d - HP sol projection: %f sec\n",
-		   is+1,t2-t1);	  
-	
-	t1 = MPI_Wtime();
-	K_vector->downloadFromCuda(sol_LP,flag_eo);
-	K_vector->download();
-	
-	// Solution is projected and put into x, x <- (1-UU^dag) x
-	deflation->projectVector(*K_vecdef,*K_vector,is+1,NeV_defl);
-	K_vecdef->uploadToCuda(x_LP,flag_eo);
-	t2 = MPI_Wtime();
-	printfQuda("TIME_REPORT: NHP %04d - LP sol projection: %f sec\n",
-		   is+1,t2-t1);
-      
-	
-	// Contractions
-	//-------------------------------------------------
-	t1 = MPI_Wtime();
-	//-high-precision
-	oneEndTrick_w_One_Der<double>(*x, *tmp3, *tmp4,param, 
-				      gen_uloc[dstep], std_uloc[dstep], 
-				      gen_oneD[dstep], std_oneD[dstep], 
-				      gen_csvC[dstep], std_csvC[dstep]); 
-	t2 = MPI_Wtime();
-	printfQuda("TIME_REPORT: NHP %04d - HP Contractions: %f sec\n",
-		   is+1,t2-t1);
-	t1 = MPI_Wtime();
-	//-low-precision
-	oneEndTrick_w_One_Der<double>(*x_LP, *tmp3, *tmp4,param, 
-				      gen_uloc_LP[dstep],std_uloc_LP[dstep],
-				      gen_oneD_LP[dstep],std_oneD_LP[dstep],
-				      gen_csvC_LP[dstep],std_csvC_LP[dstep]);
-	t2 = MPI_Wtime();
-	printfQuda("TIME_REPORT: NHP %04d - LP Contractions: %f sec\n",
-		   is+1,t2-t1);
-	
-	t4 = MPI_Wtime();
-	printfQuda("### TIME_REPORT: NHP %04d - Finished in %f sec\n",
-		   is+1,t4-t3);
-	
-	
-	// FFT and copy to write buffers
-	//-------------------------------------------------      
-	if( (is+1)%Nd == 0){
-	  if(dstep==0) iPrint++;
-	  t1 = MPI_Wtime();
-	  if(GK_nProc[2]==1){      
-	    doCudaFFT_v2<double>(std_uloc[dstep]   ,tmp_loop);  
-	    copyLoopToWriteBuf(buf_std_uloc_HP[dstep], tmp_loop, 
-				iPrint, info.Q_sq, Nmoms, mom); // Scalar
-	    doCudaFFT_v2<double>(std_uloc_LP[dstep],tmp_loop);  
-	    copyLoopToWriteBuf(buf_std_uloc_LP[dstep], tmp_loop, 
-			       iPrint, info.Q_sq, Nmoms, mom);
-
-	    doCudaFFT_v2<double>(gen_uloc[dstep]   ,tmp_loop);
-	    copyLoopToWriteBuf(buf_gen_uloc_HP[dstep], tmp_loop, 
-			       iPrint, info.Q_sq, Nmoms, mom); // dOp
-	    doCudaFFT_v2<double>(gen_uloc_LP[dstep],tmp_loop);  
-	    copyLoopToWriteBuf(buf_gen_uloc_LP[dstep], tmp_loop, 
-			       iPrint, info.Q_sq, Nmoms, mom);
-	    
-	    for(int mu = 0 ; mu < 4 ; mu++){
-	      doCudaFFT_v2<double>(std_oneD[dstep][mu]   ,tmp_loop);  
-	      copyLoopToWriteBuf(buf_std_oneD_HP[dstep][mu], tmp_loop, 
-				 iPrint,info.Q_sq,Nmoms,mom); // Loops
-	      doCudaFFT_v2<double>(std_oneD_LP[dstep][mu], tmp_loop);  
-	      copyLoopToWriteBuf(buf_std_oneD_LP[dstep][mu], tmp_loop,
-				 iPrint,info.Q_sq,Nmoms,mom);
-
-	      doCudaFFT_v2<double>(std_csvC[dstep][mu]   ,tmp_loop);  
-	      copyLoopToWriteBuf(buf_std_csvC_HP[dstep][mu], tmp_loop, 
-				 iPrint,info.Q_sq,Nmoms,mom); // LoopsCv
-	      doCudaFFT_v2<double>(std_csvC_LP[dstep][mu],tmp_loop);  
-	      copyLoopToWriteBuf(buf_std_csvC_LP[dstep][mu],tmp_loop,
-				 iPrint,info.Q_sq,Nmoms,mom);
-
-	      doCudaFFT_v2<double>(gen_oneD[dstep][mu]   ,tmp_loop);
-	      copyLoopToWriteBuf(buf_gen_oneD_HP[dstep][mu],tmp_loop,
-				 iPrint,info.Q_sq,Nmoms,mom); // LpsDw
-	      doCudaFFT_v2<double>(gen_oneD_LP[dstep][mu],tmp_loop);  
-	      copyLoopToWriteBuf(buf_gen_oneD_LP[dstep][mu],tmp_loop,
-				 iPrint,info.Q_sq,Nmoms,mom);
-	      doCudaFFT_v2<double>(gen_csvC[dstep][mu]   ,tmp_loop);  
-	      copyLoopToWriteBuf(buf_gen_csvC_HP[dstep][mu],tmp_loop,
-				 iPrint,info.Q_sq,Nmoms,mom); // LpsDwCv
-	      doCudaFFT_v2<double>(gen_csvC_LP[dstep][mu],tmp_loop);  
-	      copyLoopToWriteBuf(buf_gen_csvC_LP[dstep][mu],tmp_loop,
-				 iPrint,info.Q_sq,Nmoms,mom);
-	    }
-	  }
-	  else if(GK_nProc[2]>1){
-	    performFFT<double>(buf_std_uloc_HP[dstep], std_uloc[dstep], 
-			       iPrint, Nmoms, momQsq);  
-	    performFFT<double>(buf_std_uloc_LP[dstep], std_uloc_LP[dstep], 
-			       iPrint, Nmoms, momQsq);
-	    performFFT<double>(buf_gen_uloc_HP[dstep], gen_uloc[dstep], 
-			       iPrint, Nmoms, momQsq);  
-	    performFFT<double>(buf_gen_uloc_LP[dstep], gen_uloc_LP[dstep], 
-			       iPrint, Nmoms, momQsq);
-	    
-	    for(int mu=0;mu<4;mu++){
-	      performFFT<double>(buf_std_oneD_HP[dstep][mu], 
-				 std_oneD[dstep][mu], iPrint, 
-				 Nmoms, momQsq);  
-	      performFFT<double>(buf_std_oneD_LP[dstep][mu], 
-				 std_oneD_LP[dstep][mu], iPrint, 
-				 Nmoms, momQsq);
-	      performFFT<double>(buf_std_csvC_HP[dstep][mu], 
-				 std_csvC[dstep][mu], iPrint, 
-				 Nmoms, momQsq);  
-	      performFFT<double>(buf_std_csvC_LP[dstep][mu], 
-				 std_csvC_LP[dstep][mu], iPrint, 
-				 Nmoms, momQsq);
-	      performFFT<double>(buf_gen_oneD_HP[dstep][mu], 
-				 gen_oneD[dstep][mu], iPrint, 
-				 Nmoms, momQsq);  
-	      performFFT<double>(buf_gen_oneD_LP[dstep][mu], 
-				 gen_oneD_LP[dstep][mu], iPrint, 
-				 Nmoms, momQsq);
-	      performFFT<double>(buf_gen_csvC_HP[dstep][mu], 
-				 gen_csvC[dstep][mu], iPrint, 
-				 Nmoms, momQsq);  
-	      performFFT<double>(buf_gen_csvC_LP[dstep][mu], 
-				 gen_csvC_LP[dstep][mu], iPrint, 
-				 Nmoms, momQsq);
-	    }
-	  }
-	  t2 = MPI_Wtime();
-	  printfQuda("Loops for NHP = %04d FFT'ed and copied to write buffers in %f sec\n",is+1,t2-t1);
-	}//-if (is+1)
-      }//-deflation step
-
-      delete sol;
-      delete sol_LP;
-
-    }//-Nstoch
-    
-    //-Write the high-precision part
-    for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
-      int NeV_defl = loopInfo.deflStep[dstep];
-
-      t1 = MPI_Wtime();
-      sprintf(loop_stoch_fname,"%s_stoch_TSM_NeV%d_HighPrec",
-	      loopInfo.loop_fname, NeV_defl);
-      if(LoopFileFormat==ASCII_FORM){ 
-	// Write the loops in ASCII format
-	writeLoops_ASCII(buf_std_uloc_HP[dstep], loop_stoch_fname, 
-			 loopInfo, momQsq, 0, 0, 
-			 stoch_part, useTSM, HighPrecSum); // Scalar
-	writeLoops_ASCII(buf_gen_uloc_HP[dstep], loop_stoch_fname, 
-			 loopInfo, momQsq, 1, 0, stoch_part, 
-			 useTSM, HighPrecSum); // dOp
-	for(int mu = 0 ; mu < 4 ; mu++){
-	  writeLoops_ASCII(buf_std_oneD_HP[dstep][mu], loop_stoch_fname, 
-			   loopInfo, momQsq, 2, mu, 
-			   stoch_part, useTSM, HighPrecSum); // Loops
-	  writeLoops_ASCII(buf_std_csvC_HP[dstep][mu], loop_stoch_fname, 
-			   loopInfo, momQsq, 3, mu, 
-			   stoch_part, useTSM, HighPrecSum); // LoopsCv
-	  writeLoops_ASCII(buf_gen_oneD_HP[dstep][mu], loop_stoch_fname, 
-			   loopInfo, momQsq, 4, mu, 
-			   stoch_part, useTSM, HighPrecSum); // LpsDw
-	  writeLoops_ASCII(buf_gen_csvC_HP[dstep][mu], loop_stoch_fname, 
-			   loopInfo, momQsq, 5, mu, 
-			   stoch_part, useTSM, HighPrecSum); // LpsDwCv
-	}
-      }
-      else if(LoopFileFormat==HDF5_FORM){
-	// Write the loops in HDF5 format
-	writeLoops_HDF5(buf_std_uloc_HP[dstep], buf_gen_uloc_HP[dstep], 
-			buf_std_oneD_HP[dstep], buf_std_csvC_HP[dstep], 
-			buf_gen_oneD_HP[dstep], buf_gen_csvC_HP[dstep],
-			loop_stoch_fname, loopInfo, momQsq, 
-			stoch_part, useTSM, HighPrecSum);
-      }
-      t2 = MPI_Wtime();
-      printfQuda("Writing the high-precision loops for NeV = %d completed in %f sec.\n",NeV_defl,t2-t1);
-      
-      //-Write the low-precision part
-      t1 = MPI_Wtime();
-      sprintf(loop_stoch_fname,"%s_stoch_TSM_NeV%d_LowPrec",
-	      loopInfo.loop_fname, NeV_defl);
-      if(LoopFileFormat==ASCII_FORM){ 
-	// Write the loops in ASCII format
-	writeLoops_ASCII(buf_std_uloc_LP[dstep], loop_stoch_fname, 
-			 loopInfo, momQsq, 0, 0, 
-			 stoch_part, useTSM, HighPrecSum); // Scalar
-	writeLoops_ASCII(buf_gen_uloc_LP[dstep], loop_stoch_fname, 
-			 loopInfo, momQsq, 1, 0, 
-			 stoch_part, useTSM, HighPrecSum); // dOp
-	for(int mu = 0 ; mu < 4 ; mu++){
-	  writeLoops_ASCII(buf_std_oneD_LP[dstep][mu], loop_stoch_fname, 
-			   loopInfo, momQsq, 2, mu, 
-			   stoch_part, useTSM, HighPrecSum); // Loops
-	  writeLoops_ASCII(buf_std_csvC_LP[dstep][mu], loop_stoch_fname, 
-			   loopInfo, momQsq, 3, mu, 
-			   stoch_part, useTSM, HighPrecSum); // LoopsCv
-	  writeLoops_ASCII(buf_gen_oneD_LP[dstep][mu], loop_stoch_fname, 
-			   loopInfo, momQsq, 4, mu, 
-			   stoch_part, useTSM, HighPrecSum); // LpsDw
-	  writeLoops_ASCII(buf_gen_csvC_LP[dstep][mu], loop_stoch_fname, 
-			   loopInfo, momQsq, 5, mu, 
-			   stoch_part, useTSM, HighPrecSum); // LpsDwCv
-	}
-      }
-      else if(LoopFileFormat==HDF5_FORM){ 
-	// Write the loops in HDF5 format
-	writeLoops_HDF5(buf_std_uloc_LP[dstep], buf_gen_uloc_LP[dstep], 
-			buf_std_oneD_LP[dstep], buf_std_csvC_LP[dstep], 
-			buf_gen_oneD_LP[dstep], buf_gen_csvC_LP[dstep],
-			loop_stoch_fname, loopInfo, momQsq, 
-			stoch_part, useTSM, HighPrecSum);
-      }
-      t2 = MPI_Wtime();
-      printfQuda("Writing the low-precision loops for NeV = %d completed in %f sec.\n",NeV_defl,t2-t1);
-    }//-dstep
-    
-  }//-useTSM
-  
-  gsl_rng_free(rNum);
-  
-  printfQuda("\n ### Stochastic part calculation Done ###\n");
-
-  //======================================================================//
-  //================ M E M O R Y   C L E A N - U P =======================// 
-  //======================================================================//
-
-  printfQuda("\nCleaning up...\n");
-  
-  //-Free the momentum matrices
-  for(int ip=0; ip<SplV; ip++) free(mom[ip]);
-  free(mom);
-  for(int ip=0;ip<Nmoms;ip++) free(momQsq[ip]);
-  free(momQsq);
-  //---------------------------
-  
-  //-Free loop buffers
-  cudaFreeHost(tmp_loop);
-  for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
-    //-accumulation buffers
-    cudaFreeHost(std_uloc[dstep]);
-    cudaFreeHost(gen_uloc[dstep]);
-    for(int mu = 0 ; mu < 4 ; mu++){
-      cudaFreeHost(std_oneD[dstep][mu]);
-      cudaFreeHost(gen_oneD[dstep][mu]);
-      cudaFreeHost(std_csvC[dstep][mu]);
-      cudaFreeHost(gen_csvC[dstep][mu]);
-    }
-    free(std_oneD[dstep]);
-    free(gen_oneD[dstep]);
-    free(std_csvC[dstep]);
-    free(gen_csvC[dstep]);   
-    
-    //-write buffers
-    free(buf_std_uloc[dstep]);
-    free(buf_gen_uloc[dstep]);
-    for(int mu = 0 ; mu < 4 ; mu++){
-      free(buf_std_oneD[dstep][mu]);
-      free(buf_std_csvC[dstep][mu]);
-      free(buf_gen_oneD[dstep][mu]);
-      free(buf_gen_csvC[dstep][mu]);
-    }
-    free(buf_std_oneD[dstep]);
-    free(buf_std_csvC[dstep]);
-    free(buf_gen_oneD[dstep]);
-    free(buf_gen_csvC[dstep]);
-  }//-dstep
-  //---------------------------
-  
-  //-Free the extra buffers if using TSM
-  if(useTSM){
-    for(int dstep=0;dstep<loopInfo.nSteps_defl;dstep++){
-      cudaFreeHost(std_uloc_LP[dstep]);
-      cudaFreeHost(gen_uloc_LP[dstep]);
-      for(int mu = 0 ; mu < 4 ; mu++){
-	cudaFreeHost(std_oneD_LP[dstep][mu]);
-	cudaFreeHost(gen_oneD_LP[dstep][mu]);
-	cudaFreeHost(std_csvC_LP[dstep][mu]);
-	cudaFreeHost(gen_csvC_LP[dstep][mu]);
-      }
-      free(std_oneD_LP[dstep]);
-      free(gen_oneD_LP[dstep]);
-      free(std_csvC_LP[dstep]);
-      free(gen_csvC_LP[dstep]);
-     
-      free(buf_std_uloc_LP[dstep]); free(buf_std_uloc_HP[dstep]);
-      free(buf_gen_uloc_LP[dstep]); free(buf_gen_uloc_HP[dstep]);
-      for(int mu = 0 ; mu < 4 ; mu++){
-	free(buf_std_oneD_LP[dstep][mu]); free(buf_std_oneD_HP[dstep][mu]);
-	free(buf_std_csvC_LP[dstep][mu]); free(buf_std_csvC_HP[dstep][mu]);
-	free(buf_gen_oneD_LP[dstep][mu]); free(buf_gen_oneD_HP[dstep][mu]);
-	free(buf_gen_csvC_LP[dstep][mu]); free(buf_gen_csvC_HP[dstep][mu]);
-      }
-      free(buf_std_oneD_LP[dstep]); free(buf_std_oneD_HP[dstep]);
-      free(buf_std_csvC_LP[dstep]); free(buf_std_csvC_HP[dstep]);
-      free(buf_gen_oneD_LP[dstep]); free(buf_gen_oneD_HP[dstep]);
-      free(buf_gen_csvC_LP[dstep]); free(buf_gen_csvC_HP[dstep]);
-    }//-dstep
-  }//-useTSM
-  //------------------------------------
-
-  free(input_vector);
-
-  delete deflation;
-  delete d;
-  delete dSloppy;
-  delete dPre;
-  delete K_vecdef;
-  delete K_vector;
-  delete K_gauge;
-  delete x;
-  delete b;
-  delete tmp3;
-  delete tmp4;
-
-  if(useTSM){
-    delete x_LP;
-  }
-
-  printfQuda("...Done\n");
-  popVerbosity();
-  saveTuneCache();
-  profileInvert.TPSTOP(QUDA_PROFILE_TOTAL);
-}
-
-#endif

--- a/lib/qudaQKXTM_Contraction_Kepler.cpp
+++ b/lib/qudaQKXTM_Contraction_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-//#include <mkl.h> //QXKTM: FIXME
-#include <cblas.h>
-#include <common.h>
+#include <mkl.h>
+//#include <cblas.h>
+//#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Contraction_Kepler.cpp
+++ b/lib/qudaQKXTM_Contraction_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-#include <mkl.h>
-//#include <cblas.h>
-//#include <common.h>
+//#include <mkl.h>
+#include <cblas.h>
+#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Deflation_Kepler.cpp
+++ b/lib/qudaQKXTM_Deflation_Kepler.cpp
@@ -1788,7 +1788,7 @@ projectVector(QKXTM_Vector_Kepler<Float> &vec_defl,
   if(!isFullOp) errorQuda("projectVector: This function only works with the Full Operator\n");
   
   if(NeV_defl == 0){
-    printfQuda("NeV = %d. Will not deflate source vector!\n",NeV_defl);
+    printfQuda("projectVector: Got NeV = %d. Will not project vector!\n",NeV_defl);
     vec_defl.packVector((Float*) vec_in.H_elem());
     vec_defl.loadVector();
     return;
@@ -1904,6 +1904,6 @@ projectVector(QKXTM_Vector_Kepler<Float> &vec_defl,
   free(out_vec);
   free(out_vec_reduce);
 
-  printfQuda("projectVector: Deflation of the source vector completed succesfully\n");
+  //  printfQuda("projectVector: Deflation of the source vector completed succesfully\n");
 }
 

--- a/lib/qudaQKXTM_Deflation_Kepler.cpp
+++ b/lib/qudaQKXTM_Deflation_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-//#include <mkl.h> //QXKTM: FIXME
-#include <cblas.h>
-#include <common.h>
+#include <mkl.h>
+//#include <cblas.h>
+//#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Deflation_Kepler.cpp
+++ b/lib/qudaQKXTM_Deflation_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-#include <mkl.h>
-//#include <cblas.h>
-//#include <common.h>
+//#include <mkl.h>
+#include <cblas.h>
+#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Field_Kepler.cpp
+++ b/lib/qudaQKXTM_Field_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-//#include <mkl.h> //QXKTM: FIXME
-#include <cblas.h>
-#include <common.h>
+#include <mkl.h>
+//#include <cblas.h>
+//#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Field_Kepler.cpp
+++ b/lib/qudaQKXTM_Field_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-#include <mkl.h>
-//#include <cblas.h>
-//#include <common.h>
+//#include <mkl.h>
+#include <cblas.h>
+#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Gauge_Kepler.cpp
+++ b/lib/qudaQKXTM_Gauge_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-//#include <mkl.h> //QXKTM: FIXME
-#include <cblas.h>
-#include <common.h>
+#include <mkl.h>
+//#include <cblas.h>
+//#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Gauge_Kepler.cpp
+++ b/lib/qudaQKXTM_Gauge_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-#include <mkl.h>
-//#include <cblas.h>
-//#include <common.h>
+//#include <mkl.h>
+#include <cblas.h>
+#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Kepler_utils.cpp
+++ b/lib/qudaQKXTM_Kepler_utils.cpp
@@ -11,9 +11,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-//#include <mkl.h> //QXKTM: FIXME
-#include <cblas.h>
-#include <common.h>
+#include <mkl.h>
+//#include <cblas.h>
+//#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Kepler_utils.cpp
+++ b/lib/qudaQKXTM_Kepler_utils.cpp
@@ -11,9 +11,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-#include <mkl.h>
-//#include <cblas.h>
-//#include <common.h>
+//#include <mkl.h>
+#include <cblas.h>
+#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Loops_Kepler.cpp
+++ b/lib/qudaQKXTM_Loops_Kepler.cpp
@@ -11,9 +11,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-//#include <mkl.h> //QXKTM: FIXME
-#include <cblas.h>
-#include <common.h>
+#include <mkl.h>
+//#include <cblas.h>
+//#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Loops_Kepler.cpp
+++ b/lib/qudaQKXTM_Loops_Kepler.cpp
@@ -97,7 +97,7 @@ Loop_w_One_Der_FullOp_Exact(int n, QudaInvertParam *param,
   cudaColorSpinorField *x1 = NULL;
 
   double *eigVec = (double*) malloc(bytes_total_length_per_NeV);
- memcpy(eigVec,&(h_elem[n*total_length_per_NeV]),bytes_total_length_per_NeV);
+  memcpy(eigVec,&(h_elem[n*total_length_per_NeV]),bytes_total_length_per_NeV);
 
   QKXTM_Vector_Kepler<double> *Kvec = 
     new QKXTM_Vector_Kepler<double>(BOTH,VECTOR);

--- a/lib/qudaQKXTM_Loops_Kepler.cpp
+++ b/lib/qudaQKXTM_Loops_Kepler.cpp
@@ -11,9 +11,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-#include <mkl.h>
-//#include <cblas.h>
-//#include <common.h>
+//#include <mkl.h>
+#include <cblas.h>
+#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Propagator_Kepler.cpp
+++ b/lib/qudaQKXTM_Propagator_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-//#include <mkl.h> //QXKTM: FIXME
-#include <cblas.h>
-#include <common.h>
+#include <mkl.h>
+//#include <cblas.h>
+//#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Propagator_Kepler.cpp
+++ b/lib/qudaQKXTM_Propagator_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-#include <mkl.h>
-//#include <cblas.h>
-//#include <common.h>
+//#include <mkl.h>
+#include <cblas.h>
+#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Vector_Kepler.cpp
+++ b/lib/qudaQKXTM_Vector_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-//#include <mkl.h> //QXKTM: FIXME
-#include <cblas.h>
-#include <common.h>
+#include <mkl.h>
+//#include <cblas.h>
+//#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/lib/qudaQKXTM_Vector_Kepler.cpp
+++ b/lib/qudaQKXTM_Vector_Kepler.cpp
@@ -9,9 +9,9 @@
 #include <errno.h>
 #include <mpi.h>
 #include <limits>
-#include <mkl.h>
-//#include <cblas.h>
-//#include <common.h>
+//#include <mkl.h>
+#include <cblas.h>
+#include <common.h>
 #include <omp.h>
 #include <hdf5.h>
  

--- a/qkxtm/CalcMG_Loops_w_oneD_TSM_wExact.cpp
+++ b/qkxtm/CalcMG_Loops_w_oneD_TSM_wExact.cpp
@@ -114,7 +114,6 @@ extern char loop_fname[];
 extern char *loop_file_format;
 extern int Ndump;
 extern int smethod;
-extern bool fullOp_stochEO;
 extern char source_type[];
 extern char filename_dSteps[];
 extern bool useTSM;
@@ -138,21 +137,6 @@ extern double amin;
 extern double amax;
 extern bool isEven;
 extern bool isFullOp;
-
-//-C.K. ARPACK Parameters if we are using full operator and 
-//even-odd preconditioning for the stochastic part
-extern int PolyDeg_EO;
-extern int nEv_EO;
-extern int nKv_EO;
-extern char *spectrumPart_EO;
-extern bool isACC_EO;
-extern double tolArpack_EO;
-extern int maxIterArpack_EO;
-extern char arpack_logfile_EO[];
-extern double amin_EO;
-extern double amax_EO;
-extern bool isEven_EO;
-extern bool isFullOp_EO;
 
 
 namespace quda {
@@ -556,35 +540,6 @@ int main(int argc, char **argv)
     exit(-1);
   }
 
-  //-C.K. ARPACK Parameters if we are using full operator and 
-  //even-odd preconditioning for the stochastic part
-  qudaQKXTM_arpackInfo arpackInfoEO;
-  if(isFullOp && fullOp_stochEO){
-    arpackInfoEO.PolyDeg = PolyDeg_EO;
-    arpackInfoEO.nEv = nEv_EO;
-    arpackInfoEO.nKv = nKv_EO;
-    arpackInfoEO.isACC = isACC_EO;
-    arpackInfoEO.tolArpack = tolArpack_EO;
-    arpackInfoEO.maxIterArpack = maxIterArpack_EO;
-    strcpy(arpackInfoEO.arpack_logfile,arpack_logfile_EO);
-    arpackInfoEO.amin = amin_EO;
-    arpackInfoEO.amax = amax_EO;
-    arpackInfoEO.isEven = isEven_EO;
-    // by default we are not using the Full Operator, hard-coded
-    arpackInfoEO.isFullOp = false;
-
-    if(strcmp(spectrumPart_EO,"SR")==0)      arpackInfoEO.spectrumPart = SR;
-    else if(strcmp(spectrumPart_EO,"LR")==0) arpackInfoEO.spectrumPart = LR;
-    else if(strcmp(spectrumPart_EO,"SM")==0) arpackInfoEO.spectrumPart = SM;
-    else if(strcmp(spectrumPart_EO,"LM")==0) arpackInfoEO.spectrumPart = LM;
-    else if(strcmp(spectrumPart_EO,"SI")==0) arpackInfoEO.spectrumPart = SI;
-    else if(strcmp(spectrumPart_EO,"LI")==0) arpackInfoEO.spectrumPart = LI;
-    else{
-      printf("Error: Your spectrumPart option is suspicious\n");
-      exit(-1);
-    }
-  }
-
   //-C.K. General QKXTM information
   qudaQKXTMinfo_Kepler info;
   info.lL[0] = xdim;
@@ -607,8 +562,6 @@ int main(int argc, char **argv)
   loopInfo.Ndump = Ndump;
   loopInfo.traj = traj;
   loopInfo.Qsq = Q_sq;
-  //Hardcoded in this function
-  loopInfo.fullOp_stochEO = false;
   strcpy(loopInfo.loop_fname,loop_fname);
 
   if( strcmp(loop_file_format,"ASCII")==0 || 
@@ -738,8 +691,7 @@ int main(int argc, char **argv)
 
   //Launch calculation.
   calcMG_loop_wOneD_TSM_wExact(gauge_Plaq, &EVinv_param, &inv_param, 
-			       &gauge_param, arpackInfo, arpackInfoEO,
-			       loopInfo, info);
+			       &gauge_param, arpackInfo, loopInfo, info);
   
   // free the multigrid solver
   destroyMultigridQuda(mg_preconditioner);

--- a/qkxtm/CalcMG_Loops_w_oneD_TSM_wExact.cpp
+++ b/qkxtm/CalcMG_Loops_w_oneD_TSM_wExact.cpp
@@ -661,11 +661,14 @@ int main(int argc, char **argv)
   QudaInvertParam inv_param = newQudaInvertParam();
   setInvertParam(inv_param);
 
+
+  //-C.K. Operator parameters for the Full Operator deflation
   QudaInvertParam EVinv_param = newQudaInvertParam();
   EVinv_param = inv_param;
   if(isEven) EVinv_param.matpc_type = QUDA_MATPC_EVEN_EVEN_ASYMMETRIC;
   else EVinv_param.matpc_type = QUDA_MATPC_ODD_ODD_ASYMMETRIC;
 
+  EVinv_param.mass_normalization = QUDA_MASS_NORMALIZATION;
 
   // declare the dimensions of the communication grid
   initCommsGridQuda(4, gridsize_from_cmdline, NULL, NULL);
@@ -692,6 +695,7 @@ int main(int argc, char **argv)
   for(int mu = 0 ; mu < 4 ; mu++)
     memcpy(gauge_Plaq[mu],gauge[mu],V*9*2*sizeof(double));
   mapEvenOddToNormalGauge(gauge_Plaq,gauge_param,xdim,ydim,zdim,tdim);
+  applyBoundaryCondition(gauge, V/2 ,&gauge_param);
 
   // start the timer
   double time0 = -((double)clock());

--- a/qkxtm/CalcMG_Loops_w_oneD_TSM_wExact.cpp
+++ b/qkxtm/CalcMG_Loops_w_oneD_TSM_wExact.cpp
@@ -113,7 +113,6 @@ extern unsigned long int seed;
 extern char loop_fname[];
 extern char *loop_file_format;
 extern int Ndump;
-extern int smethod;
 extern char source_type[];
 extern char filename_dSteps[];
 extern bool useTSM;

--- a/qkxtm/QKXTM_util.cpp
+++ b/qkxtm/QKXTM_util.cpp
@@ -1617,7 +1617,6 @@ int TSM_NdumpLP = 0;
 long int TSM_maxiter = 0;
 double TSM_tol = 0;
 int smethod = 0;
-bool fullOp_stochEO = false;
 #ifdef HAVE_ARPACK
 //- Loop params with ARPACK enabled
 char filename_dSteps[512]="none";
@@ -1639,22 +1638,8 @@ int maxIterArpack = 100000;
 char arpack_logfile[512] = "arpack.log";
 double amin = 3.0e-4;
 double amax = 3.5;
-//bool isEven = false;
 bool isFullOp = false;
 
-//-C.K. ARPACK Parameters for Even-Odd preconditioning for the stochastic part when using the Full Operator
-int PolyDeg_EO = 100;     // degree of the Chebysev polynomial
-int nEv_EO = 100;         // Number of the eigenvectors we want
-int nKv_EO = 200;         // total size of Krylov space
-char *spectrumPart_EO = "SR"; // Which part of the spectrum we want to solve
-bool isACC_EO = true;
-double tolArpack_EO = 1.0e-5;
-int maxIterArpack_EO = 100000;
-char arpack_logfile_EO[512] = "arpack_EO.log";
-double amin_EO = 3.0e-4;
-double amax_EO = 3.5;
-bool isEven_EO = false;
-bool isFullOp_EO = false;
 #endif
 
 //===========//
@@ -1784,9 +1769,10 @@ void usage(char** argv )
   printf("    --mg-nu-pre  <1-20>                       # The number of pre-smoother applications to do at each multigrid level (default 2)\n");
   printf("    --mg-nu-post <1-20>                       # The number of post-smoother applications to do at each multigrid level (default 2)\n");
   printf("    --mg-smoother                             # The smoother to use for multigrid (default mr)\n");
-  printf("    --mg-block-size <level x y z t>           # Set the geometric block size for the each multigrid level's transfer operator (default 4 4 4 4)\n");
+  printf("    --mg-block-size <level x y z t>           # Set the geometric block size for the each multigrid level's transfer operator(default 4 4 4 4)\n");
   printf("    --mg-generate-nullspace <true/false>      # Generate the null-space vector dynamically (default true)\n");
-  printf("    --mg-generate-all-levels <true/talse>     # true=generate nul space on all levels, false=generate on level 0 and create other levels from that (default true)\n");
+  printf("    --mg-generate-all-levels <true/talse>     # true=generate nul space on all levels, false=generate on level 0 "
+	 "                                                and create other levels from that (default true)\n");
   printf("    --mg-load-vec file                        # Load the vectors \"file\" for the multigrid_test (requires QIO)\n");
   printf("    --mg-save-vec file                        # Save the generated null-space vectors \"file\" from the multigrid_test (requires QIO)\n");
   printf("    --nsrc <n>                                # How many spinors to apply the dslash to simultaneusly (experimental for staggered only)\n");
@@ -1818,7 +1804,8 @@ void usage(char** argv )
   printf("    --t_source                                # Source position in t direction (default 0)\n");
   printf("    --pathListSinkSource                      # Path to sink-source separations (default \" list_tsinksource.txt \")\n");
   printf("    --pathListRun3pt                          # Path to source positions to run for 2pt- and 3pt- functions (default \" listrun3pt.txt \")\n");
-  printf("    --run3pt                                  # Option to choose whether to run for all (=all/ALL) source-positions, for none (=none/NONE) or only some (=file/FILE, given in --pathListRun3pt) (default \" all \")\n");
+  printf("    --run3pt                                  # Option to choose whether to run for all (=all/ALL) source-positions, for none (=none/NONE)\n"
+	 "                                                   or only some (=file/FILE, given in --pathListRun3pt) (default \" all \")\n");
   printf("    --Ntsink                                  # Number of sink-source separations (default \" list_tsinksource.txt \")\n");
   printf("    --Q-sqMax                                 # The maximum Q^2 momentum (loop/correlators) (default 0)\n");
   printf("    --nsmearAPE                               # Number of APE smearing iterations (default 20)\n");
@@ -1844,7 +1831,6 @@ void usage(char** argv )
   printf("    --loop-filename                           # File name to save loops (default \"loop\")\n");
   printf("    --loop-file-format                        # file format for the loops, ASCII/HDF5 (default \"ASCII_format\")\n");
   printf("    --source-type                             # Stochastic source type (unity/random) (default random)\n");
-  printf("    --stochEO                                 # Use EO precon for the stochastic part when using the Full Operator (yes/no, default: no\n");
   printf("    --UseEven                                 # Whether to use Even-Even operator (yes/no, default no)\n");
   printf("    --useTSM                                  # Use (or not) the truncated solver method for the Full Operator (yes/no, default: no\n");
   printf("    --TSM-NHP                                 # Number of High-precision sources for TSM\n");
@@ -1873,20 +1859,6 @@ void usage(char** argv )
   printf("    --UseFullOp                                 # Whether to use the Full Operator (yes,no, default no)\n");
   printf("    --defl_steps                                # File to deflation steps (default none)\n");
 
-  //-C.K. ARPACK STOCH INPUT
-  printf("    --PolyDeg-EO                                # The degree of the polynomial Acceleration (default 100)\n");
-  printf("    --nEv-EO                                    # Number of eigenvalues requested by ARPACK (default 100)\n");
-  printf("    --nKv-EO                                    # Total size of the Krylov space used by ARPACK (default 200)\n");
-  printf("    --spectrumPart                              # Which part of the spectrum we need (Options: SR,LR,SM,LM,SI,LI, default SR)\n");
-  printf("    --isACC-EO                                  # Whether we want to use polynomial acceleration (yes/no, default yes)\n");
-  printf("    --tolARPACK-EO                              # Tolerance for convergence, used by ARPACK (default 1.0e-5)\n");
-  printf("    --maxIterARPACK-EO                          # Maximum iterations number for ARPACK (default 100000)\n");
-  printf("    --pathArpackLogfile-EO                      # Path to the ARPACK log file (default  \"arpack.log\")\n");
-  printf("    --aminARPACK-EO                             # amin parameter used in Cheb. Poly. Acc. (default 3.0e-4)\n");
-  printf("    --amaxARPACK-EO                             # amax parameter used in Cheb. Poly. Acc. (default 3.5)\n");
-  printf("    --UseEven-EO                                # Whether to use Even-Even operator (yes/no, default no)\n");
-  printf("    --UseFullOp-EO                              # Whether to use the Full Operator (yes,no, default no)\n");
-  printf("    --defl_steps-EO                             # File to deflation steps (default none)\n");
 #endif
   //--------//
 
@@ -3238,20 +3210,6 @@ int process_command_line_option(int argc, char** argv, int* idx)
     goto out;
   }
 
-  if( strcmp(argv[i], "--stochEO") ==0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    if( strcmp(argv[i+1],"yes")==0 || 
-	strcmp(argv[i+1],"YES")==0 ) fullOp_stochEO = true;
-    else if ( strcmp(argv[i+1],"no")==0 || 
-	      strcmp(argv[i+1],"NO")==0 ) fullOp_stochEO = false;
-    else usage(argv);
-    i++;
-    ret = 0;
-    goto out;
-  }
- 
   if( strcmp(argv[i], "--pathEigenVectorsUp") == 0){
     if (i+1 >= argc){
       usage(argv);
@@ -3399,20 +3357,6 @@ int process_command_line_option(int argc, char** argv, int* idx)
     goto out;
   }
  
-  // if( strcmp(argv[i], "--UseEven") ==0){
-  //   if(i+1 >= argc){
-  //     usage(argv);
-  //   }
-  //   if( strcmp(argv[i+1],"yes")==0 || 
-  // 	strcmp(argv[i+1],"YES")==0 ) isEven = true;
-  //   else if ( strcmp(argv[i+1],"no")==0 || 
-  // 	      strcmp(argv[i+1],"NO")==0 ) isEven = false;
-  //   else usage(argv);
-  //   i++;
-  //   ret = 0;
-  //   goto out;
-  // }
- 
   if( strcmp(argv[i], "--UseFullOp") ==0){
     if(i+1 >= argc){
       usage(argv);
@@ -3425,125 +3369,6 @@ int process_command_line_option(int argc, char** argv, int* idx)
     goto out;
   }
 
-  // C.K. ARPACK INPUT FOR EVEN-ODD PRECONDITIONING 
-  // (APPLICABLE ONLY WHEN USING THE FULL OPERATOR)
-  if( strcmp(argv[i], "--PolyDeg-EO") == 0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    PolyDeg_EO = atoi(argv[i+1]);
-    i++;
-    ret = 0;
-    goto out;
-  }
-  
-  if( strcmp(argv[i], "--nEv-EO") == 0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    nEv_EO = atoi(argv[i+1]);
-    i++;
-    ret = 0;
-    goto out;
-  }
-  
-  if( strcmp(argv[i], "--nKv-EO") == 0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    nKv_EO = atoi(argv[i+1]);
-    i++;
-    ret = 0;
-    goto out;
-  }
-  
-
-  if( strcmp(argv[i], "--spectrumPart-EO") == 0){
-    if(i+1 >= argc){
-      usage(argv);
-    }    
-    spectrumPart_EO = strdup(argv[i+1]);
-    i++;
-    ret = 0;
-    goto out;
-  }
-
-  if( strcmp(argv[i], "--isACC-EO") == 0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    if( strcmp(argv[i+1],"yes")==0 || 
-	strcmp(argv[i+1],"YES")==0 ) isACC_EO = true;
-    else if ( strcmp(argv[i+1],"no")==0 || 
-	      strcmp(argv[i+1],"NO")==0 ) isACC_EO = false;
-    else usage(argv);
-    i++;
-    ret = 0;
-    goto out;
-  }
- 
-  if( strcmp(argv[i], "--tolARPACK-EO") == 0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    tolArpack_EO = atof(argv[i+1]);
-    i++;
-    ret = 0;
-    goto out;
-  }
- 
-  if( strcmp(argv[i], "--maxIterARPACK-EO") == 0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    maxIterArpack_EO = atoi(argv[i+1]);
-    i++;
-    ret = 0;
-    goto out;
-  }
- 
-  if( strcmp(argv[i], "--pathArpackLogfile-EO") == 0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    strcpy(arpack_logfile_EO,argv[i+1]);
-    i++;
-    ret = 0;
-    goto out;
-  }
- 
-  if( strcmp(argv[i], "--aminARPACK-EO") == 0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    amin_EO = atof(argv[i+1]);
-    i++;
-    ret = 0;
-    goto out;
-  }
-
-
-  if( strcmp(argv[i], "--amaxARPACK-EO") == 0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    amax_EO = atof(argv[i+1]);
-    i++;
-    ret = 0;
-    goto out;
-  }
-
-  if( strcmp(argv[i], "--UseEven-EO") ==0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    if( strcmp(argv[i+1],"yes")==0 || strcmp(argv[i+1],"YES")==0 ) isEven_EO = true;
-    else if ( strcmp(argv[i+1],"no")==0 || strcmp(argv[i+1],"NO")==0 ) isEven_EO = false;
-    else usage(argv);
-    i++;
-    ret = 0;
-    goto out;
-  }
 #endif
  
   //-----------------------------------------------------------

--- a/qkxtm/QKXTM_util.cpp
+++ b/qkxtm/QKXTM_util.cpp
@@ -1616,7 +1616,6 @@ int TSM_NdumpHP = 0;
 int TSM_NdumpLP = 0;
 long int TSM_maxiter = 0;
 double TSM_tol = 0;
-int smethod = 0;
 #ifdef HAVE_ARPACK
 //- Loop params with ARPACK enabled
 char filename_dSteps[512]="none";
@@ -1772,7 +1771,7 @@ void usage(char** argv )
   printf("    --mg-block-size <level x y z t>           # Set the geometric block size for the each multigrid level's transfer operator(default 4 4 4 4)\n");
   printf("    --mg-generate-nullspace <true/false>      # Generate the null-space vector dynamically (default true)\n");
   printf("    --mg-generate-all-levels <true/talse>     # true=generate nul space on all levels, false=generate on level 0 "
-	 "                                                and create other levels from that (default true)\n");
+	 "                                                  and create other levels from that (default true)\n");
   printf("    --mg-load-vec file                        # Load the vectors \"file\" for the multigrid_test (requires QIO)\n");
   printf("    --mg-save-vec file                        # Save the generated null-space vectors \"file\" from the multigrid_test (requires QIO)\n");
   printf("    --nsrc <n>                                # How many spinors to apply the dslash to simultaneusly (experimental for staggered only)\n");
@@ -1805,7 +1804,7 @@ void usage(char** argv )
   printf("    --pathListSinkSource                      # Path to sink-source separations (default \" list_tsinksource.txt \")\n");
   printf("    --pathListRun3pt                          # Path to source positions to run for 2pt- and 3pt- functions (default \" listrun3pt.txt \")\n");
   printf("    --run3pt                                  # Option to choose whether to run for all (=all/ALL) source-positions, for none (=none/NONE)\n"
-	 "                                                   or only some (=file/FILE, given in --pathListRun3pt) (default \" all \")\n");
+	 "                                                  or only some (=file/FILE, given in --pathListRun3pt) (default \" all \")\n");
   printf("    --Ntsink                                  # Number of sink-source separations (default \" list_tsinksource.txt \")\n");
   printf("    --Q-sqMax                                 # The maximum Q^2 momentum (loop/correlators) (default 0)\n");
   printf("    --nsmearAPE                               # Number of APE smearing iterations (default 20)\n");
@@ -1827,7 +1826,6 @@ void usage(char** argv )
   printf("    --seed                                    # Seed for ranlux random number generator (default 100)\n");
   printf("    --Nstoch                                  # Number of stochastic noise vectors for loop (default 100)\n");
   printf("    --NdumpStep                               # Every how many noise vectors it will dump the data (default 10)\n");
-  printf("    --stoch-method                            # Use MdagM psi = (1-P)Mdag xi (1,default) or MdagM phi = Mdag xi (0)\n");
   printf("    --loop-filename                           # File name to save loops (default \"loop\")\n");
   printf("    --loop-file-format                        # file format for the loops, ASCII/HDF5 (default \"ASCII_format\")\n");
   printf("    --source-type                             # Stochastic source type (unity/random) (default random)\n");
@@ -1846,18 +1844,18 @@ void usage(char** argv )
   printf("    --pathEigenValuesDown                     # Path where the eigenVectors for up flavor are (default evals_d.dat)\n");
 
   //-C.K. ARPACK EXACT INPUT
-  printf("    --PolyDeg                                   # The degree of the polynomial Acceleration (default 100)\n");
-  printf("    --nEv                                       # Number of eigenvalues requested by ARPACK (default 100)\n");
-  printf("    --nKv                                       # Total size of the Krylov space used by ARPACK (default 200)\n");
-  printf("    --spectrumPart                              # Which part of the spectrum we need (Options: SR,LR,SM,LM,SI,LI, default SR)\n");
-  printf("    --isACC                                     # Whether we want to use polynomial acceleration (yes/no, default yes)\n");
-  printf("    --tolARPACK                                 # Tolerance for convergence, used by ARPACK (default 1.0e-5)\n");
-  printf("    --maxIterARPACK                             # Maximum iterations number for ARPACK (default 100000)\n");
-  printf("    --pathArpackLogfile                         # Path to the ARPACK log file (default  \"arpack.log\")\n");
-  printf("    --aminARPACK                                # amin parameter used in Cheb. Poly. Acc. (default 3.0e-4)\n");
-  printf("    --amaxARPACK                                # amax parameter used in Cheb. Poly. Acc. (default 3.5)\n");
-  printf("    --UseFullOp                                 # Whether to use the Full Operator (yes,no, default no)\n");
-  printf("    --defl_steps                                # File to deflation steps (default none)\n");
+  printf("    --PolyDeg                                 # The degree of the polynomial Acceleration (default 100)\n");
+  printf("    --nEv                                     # Number of eigenvalues requested by ARPACK (default 100)\n");
+  printf("    --nKv                                     # Total size of the Krylov space used by ARPACK (default 200)\n");
+  printf("    --spectrumPart                            # Which part of the spectrum we need (Options: SR,LR,SM,LM,SI,LI, default SR)\n");
+  printf("    --isACC                                   # Whether we want to use polynomial acceleration (yes/no, default yes)\n");
+  printf("    --tolARPACK                               # Tolerance for convergence, used by ARPACK (default 1.0e-5)\n");
+  printf("    --maxIterARPACK                           # Maximum iterations number for ARPACK (default 100000)\n");
+  printf("    --pathArpackLogfile                       # Path to the ARPACK log file (default  \"arpack.log\")\n");
+  printf("    --aminARPACK                              # amin parameter used in Cheb. Poly. Acc. (default 3.0e-4)\n");
+  printf("    --amaxARPACK                              # amax parameter used in Cheb. Poly. Acc. (default 3.5)\n");
+  printf("    --UseFullOp                               # Whether to use the Full Operator (yes,no, default no)\n");
+  printf("    --defl_steps                              # File to deflation steps (default none)\n");
 
 #endif
   //--------//
@@ -3073,16 +3071,6 @@ int process_command_line_option(int argc, char** argv, int* idx)
     goto out;
   }
 
-  if( strcmp(argv[i], "--stoch-method") ==0){
-    if(i+1 >= argc){
-      usage(argv);
-    }
-    smethod = atoi(argv[i+1]);
-    i++;
-    ret = 0;
-    goto out;
-  }
- 
   if( strcmp(argv[i], "--loop-filename") == 0){
     if (i+1 >= argc){
       usage(argv);


### PR DESCRIPTION
This commit upgrades the Loops TSM routine to enable the Multigrid solver for stochastic sources. This branch removes the stochastic Even/Odd deflation options and simply solves the stochastic source with a direct, preconditioned MG solver. The full spinor is then reconstructed, and the exact part is projected out from the solution, leaving the inexact part.