### PR TITLE
Options for controlling MG's BiCGStab setup max-iterations and tolerance

### DIFF
--- a/include/quda.h
+++ b/include/quda.h
@@ -362,6 +362,12 @@ extern "C" {
     /** Tolerance to use for the smoother / solver on each level */
     double smoother_tol[QUDA_MAX_MG_LEVEL];
 
+    /** C.K. BiCGStab MG setup maxiter */
+    int setup_maxiter;
+
+    /** C.K. BiCGStab MG setup tolerance */
+    double setup_tol;
+
     /** Over/under relaxation factor for the smoother at each level */
     double omega[QUDA_MAX_MG_LEVEL];
 

--- a/lib/multigrid.cpp
+++ b/lib/multigrid.cpp
@@ -697,9 +697,12 @@ namespace quda {
     SolverParam solverParam(param);
 
     // set null-space generation options - need to expose these
+    //-C.K. Setup's max iterations and tolerance can now be set from the user
     //solverParam.maxiter = 500;
-    solverParam.maxiter = 200;
-    solverParam.tol = 1e-9;
+    //solverParam.maxiter = 200;
+    //solverParam.tol = 1e-9;
+    solverParam.maxiter = param.mg_global.setup_maxiter;
+    solverParam.tol = param.mg_global.setup_tol;
     solverParam.use_init_guess = QUDA_USE_INIT_GUESS_YES;
     solverParam.delta = 1e-7;
     solverParam.inv_type = QUDA_BICGSTAB_INVERTER;

--- a/qkxtm/CalcMG_2pt3pt_EvenOdd.cpp
+++ b/qkxtm/CalcMG_2pt3pt_EvenOdd.cpp
@@ -64,6 +64,9 @@ extern double tol; // tolerance for inverter
 extern double tol_hq; // heavy-quark tolerance for inverter
 extern QudaMassNormalization normalization; // mass normalization of Dirac operators
 
+extern int mg_setup_maxiter;
+extern double mg_setup_tol;
+
 extern int niter;
 extern int nvec[];
 extern int mg_levels;
@@ -398,6 +401,9 @@ void setMultigridParam(QudaMultigridParam &mg_param) {
     mg_param.cycle_type[i] = QUDA_MG_CYCLE_RECURSIVE;
     
     mg_param.smoother[i] = smoother_type;
+
+    mg_param.setup_maxiter = mg_setup_maxiter;
+    mg_param.setup_tol = mg_setup_tol;
 
     // set the smoother / bottom solver tolerance 
     // (for MR smoothing this will be ignored)

--- a/qkxtm/CalcMG_Loops_w_oneD_TSM_EvenOdd.cpp
+++ b/qkxtm/CalcMG_Loops_w_oneD_TSM_EvenOdd.cpp
@@ -65,6 +65,9 @@ extern double tol; // tolerance for inverter
 extern double tol_hq; // heavy-quark tolerance for inverter
 extern QudaMassNormalization normalization; // mass normalization of Dirac operators
 
+extern int mg_setup_maxiter;
+extern double mg_setup_tol;
+
 extern int niter;
 extern int nvec[];
 extern int mg_levels;
@@ -401,6 +404,9 @@ void setMultigridParam(QudaMultigridParam &mg_param) {
     mg_param.cycle_type[i] = QUDA_MG_CYCLE_RECURSIVE;
     
     mg_param.smoother[i] = smoother_type;
+
+    mg_param.setup_maxiter = mg_setup_maxiter;
+    mg_param.setup_tol = mg_setup_tol;
 
     // set the smoother / bottom solver tolerance 
     // (for MR smoothing this will be ignored)

--- a/qkxtm/QKXTM_util.cpp
+++ b/qkxtm/QKXTM_util.cpp
@@ -1685,6 +1685,8 @@ double clover_coeff = 0.1;
 bool compute_clover = false;
 double tol = 1e-7;
 double tol_hq = 0.;
+int mg_setup_maxiter = 500;
+double mg_setup_tol = 5.0e-6;
 QudaTwistFlavorType twist_flavor = QUDA_TWIST_PLUS;
 bool kernel_pack_t = false;
 QudaMassNormalization normalization = QUDA_KAPPA_NORMALIZATION;
@@ -1759,6 +1761,8 @@ void usage(char** argv )
   printf("    --solve-type                              # The type of solve to do (direct, direct-pc, normop, normop-pc, normerr, normerr-pc) \n");
   printf("    --tol  <resid_tol>                        # Set L2 residual tolerance\n");
   printf("    --tolhq  <resid_hq_tol>                   # Set heavy-quark residual tolerance\n");
+  printf("    --mg-setup-maxiter <maxiter>              # Maximum # of iterations for the MG setup in BiCGStab (default 500)\n");
+  printf("    --mg-setup-tol <tol>                      # Tolerance for the MG setup in BiCGStab (default 5.0e-6)\n");
   printf("    --tune <true/false>                       # Whether to autotune or not (default true)\n");     
   printf("    --test                                    # Test method (different for each test)\n");
   printf("    --verify <true/false>                     # Verify the GPU results using CPU results (default true)\n");
@@ -2397,6 +2401,26 @@ int process_command_line_option(int argc, char** argv, int* idx)
       usage(argv);
     }
     tol_hq= atof(argv[i+1]);
+    i++;
+    ret = 0;
+    goto out;
+  }
+
+  if( strcmp(argv[i], "--mg-setup-maxiter") == 0){
+    if (i+1 >= argc){
+      usage(argv);
+    }
+    mg_setup_maxiter = atoi(argv[i+1]);
+    i++;
+    ret = 0;
+    goto out;
+  }
+
+  if( strcmp(argv[i], "--mg-setup-tol") == 0){
+    if (i+1 >= argc){
+      usage(argv);
+    }
+    mg_setup_tol = atof(argv[i+1]);
     i++;
     ret = 0;
     goto out;


### PR DESCRIPTION
With this commit, the user can now specify from command line options the tolerance and/or maximum iterations of the BiCGStab, used for creating the null vectors during the multi-grid's setup stage.