### PR TITLE
Hotfix/verbosity

### DIFF
--- a/qkxtm/CalcMG_2pt3pt_EvenOdd.cpp
+++ b/qkxtm/CalcMG_2pt3pt_EvenOdd.cpp
@@ -267,8 +267,6 @@ void setInvertParam(QudaInvertParam &inv_param) {
   inv_param.solve_type = QUDA_DIRECT_PC_SOLVE;
 
   inv_param.inv_type = QUDA_GCR_INVERTER;
-  inv_param.verbosity = QUDA_VERBOSE;
-  inv_param.verbosity_precondition = QUDA_SILENT;
 
   inv_param.inv_type_precondition = QUDA_MG_INVERTER;
 
@@ -299,17 +297,20 @@ void setInvertParam(QudaInvertParam &inv_param) {
   inv_param.maxiter_precondition = 10;
   inv_param.omega = 1.0;
 
+  //-C.K. Verbosity options
+  inv_param.verbosity_precondition = QUDA_SILENT;
 
-  //if(strcmp(verbosity_level,"verbose")==0) 
-  //inv_param.verbosity = QUDA_VERBOSE;
-  //else if(strcmp(verbosity_level,"summarize")==0) 
-  //inv_param.verbosity = QUDA_SUMMARIZE;
-  //else if(strcmp(verbosity_level,"silent")==0) 
-  //inv_param.verbosity = QUDA_SILENT;
-  //else{
-  //warningQuda("Unknown verbosity level %s. Proceeding with QUDA_SUMMARIZE verbosity level\n",verbosity_level);
-  //inv_param.verbosity = QUDA_SUMMARIZE;
-  //}
+  if(strcmp(verbosity_level,"verbose")==0)
+    inv_param.verbosity = QUDA_VERBOSE;
+  else if(strcmp(verbosity_level,"summarize")==0)
+    inv_param.verbosity = QUDA_SUMMARIZE;
+  else if(strcmp(verbosity_level,"silent")==0)
+    inv_param.verbosity = QUDA_SILENT;
+  else{
+    warningQuda("Unknown verbosity level %s. Proceeding with QUDA_SUMMARIZE verbosity level\n",verbosity_level);
+    inv_param.verbosity = QUDA_SUMMARIZE;
+  }
+
 }
 
 

--- a/qkxtm/CalcMG_Loops_w_oneD_TSM_wExact.cpp
+++ b/qkxtm/CalcMG_Loops_w_oneD_TSM_wExact.cpp
@@ -283,8 +283,6 @@ void setInvertParam(QudaInvertParam &inv_param) {
   inv_param.solve_type = QUDA_DIRECT_PC_SOLVE;  
   
   inv_param.inv_type = QUDA_GCR_INVERTER;
-  inv_param.verbosity = QUDA_VERBOSE;
-  inv_param.verbosity_precondition = QUDA_SILENT;
 
   inv_param.inv_type_precondition = QUDA_MG_INVERTER;
 
@@ -318,16 +316,20 @@ void setInvertParam(QudaInvertParam &inv_param) {
   inv_param.omega = 1.0;
 
 
-  //if(strcmp(verbosity_level,"verbose")==0) 
-  //inv_param.verbosity = QUDA_VERBOSE;
-  //else if(strcmp(verbosity_level,"summarize")==0) 
-  //inv_param.verbosity = QUDA_SUMMARIZE;
-  //else if(strcmp(verbosity_level,"silent")==0) 
-  //inv_param.verbosity = QUDA_SILENT;
-  //else{
-  //warningQuda("Unknown verbosity level %s. Proceeding with QUDA_SUMMARIZE verbosity level\n",verbosity_level);
-  //inv_param.verbosity = QUDA_SUMMARIZE;
-  //}
+  //-C.K. Verbosity options
+  inv_param.verbosity_precondition = QUDA_SILENT;
+
+  if(strcmp(verbosity_level,"verbose")==0)
+    inv_param.verbosity = QUDA_VERBOSE;
+  else if(strcmp(verbosity_level,"summarize")==0)
+    inv_param.verbosity = QUDA_SUMMARIZE;
+  else if(strcmp(verbosity_level,"silent")==0)
+    inv_param.verbosity = QUDA_SILENT;
+  else{
+    warningQuda("Unknown verbosity level %s. Proceeding with QUDA_SUMMARIZE verbosity level\n",verbosity_level);
+    inv_param.verbosity = QUDA_SUMMARIZE;
+  }
+
 }
 
 void setMultigridParam(QudaMultigridParam &mg_param) {

--- a/qkxtm/QKXTM_read_conf.h
+++ b/qkxtm/QKXTM_read_conf.h
@@ -165,11 +165,14 @@ read gauge fileld config stored in binary file
 	      
 	      strcpy	(tmpVar, "kappa =");
 	      sscanf(qcd_getParamComma(tmpVar,lime_data, lime_data_size),"%lf",&dDummy);    
-	      printfQuda("Kappa given is : %f \t Kappa conf is : %f \t check them agree\n", inv_param->kappa , dDummy);
-	      
+	      printfQuda("Kappa given is: %10.8f \t Kappa conf is: %10.8f\n", inv_param->kappa , dDummy);
+	      if(inv_param->kappa != dDummy){
+		warningQuda("Kappa given and kappa from configuration do not agree!\n");
+	      }
+
 	      strcpy	(tmpVar, "mu =");
 	      sscanf(qcd_getParamComma(tmpVar,lime_data, lime_data_size),"%lf",&dDummy);
-	      printfQuda("Mu given is : %f \t Mu conf is : %f \t may disagree for heavy quark\n" , inv_param->mu , dDummy);
+	      printfQuda("Mu given is: %f \t Mu conf is: %f \t. May disagree for heavy quarks!\n" , inv_param->mu , dDummy);
 	      
 	      free(lime_data);
 	}


### PR DESCRIPTION
These commits allow to adjust the solver's verbosity from a command line option. They also improve slightly the print messages during the check of the provided configuration's kappa and mu values.
