### PR TITLE
Support for writing the correlation functions in HDF5 more efficiently for High Q-square

### DIFF
--- a/include/qudaQKXTM_Kepler.h
+++ b/include/qudaQKXTM_Kepler.h
@@ -304,9 +304,9 @@ namespace quda {
 			       int isource, CORR_SPACE CorrSpace);
    
    void copyTwopBaryonsToHDF5_Buf(void *Twop_baryons_HDF5, void *corrBaryons,
-				  int isource, CORR_SPACE CorrSpace);
+				  int isource, CORR_SPACE CorrSpace, bool HighMomForm);
    void copyTwopMesonsToHDF5_Buf (void *Twop_mesons_HDF5 , void *corrMesons, 
-				  CORR_SPACE CorrSpace);
+				  CORR_SPACE CorrSpace, bool HighMomForm);
    
    void writeTwopBaryonsHDF5(void *twopBaryons, char *filename, 
 			     qudaQKXTMinfo_Kepler info, int isource);
@@ -321,6 +321,11 @@ namespace quda {
 				      qudaQKXTMinfo_Kepler info,int isource);
    void writeTwopMesonsHDF5_PosSpace (void *twopMesons , char *filename, 
 				      qudaQKXTMinfo_Kepler info,int isource);
+
+   void writeTwopBaryonsHDF5_MomSpace_HighMomForm(void *twopBaryons, char *filename,
+                                                  qudaQKXTMinfo_Kepler info, int isource);
+   void writeTwopMesonsHDF5_MomSpace_HighMomForm (void *twopMesons , char *filename,
+                                                  qudaQKXTMinfo_Kepler info, int isource);
 
    void seqSourceFixSinkPart1(QKXTM_Vector_Kepler<Float> &vec, 
 			      QKXTM_Propagator3D_Kepler<Float> &prop1, 
@@ -356,7 +361,7 @@ namespace quda {
 			int tsinkMtsource, CORR_SPACE CorrSpace);
    void copyThrpToHDF5_Buf(void *Thrp_HDF5, void *corrThp,  int mu, int uORd,
 			   int its, int Nsink, int pr, int thrp_sign, 
-			   THRP_TYPE type, CORR_SPACE CorrSpace);
+			   THRP_TYPE type, CORR_SPACE CorrSpace, bool HighMomForm);
    void writeThrpHDF5(void *Thrp_local_HDF5, void *Thrp_noether_HDF5, 
 		      void **Thrp_oneD_HDF5, char *filename, 
 		      qudaQKXTMinfo_Kepler info, int isource, 
@@ -371,6 +376,11 @@ namespace quda {
 			       void **Thrp_oneD_HDF5, char *filename, 
 			       qudaQKXTMinfo_Kepler info, int isource, 
 			       WHICHPARTICLE NUCLEON);
+   void writeThrpHDF5_MomSpace_HighMomForm(void *Thrp_local_HDF5,
+                                           void *Thrp_noether_HDF5,
+                                           void **Thrp_oneD_HDF5, char *filename,
+                                           qudaQKXTMinfo_Kepler info, int isource,
+                                           WHICHPARTICLE NUCLEON);
   };
 
 #ifdef HAVE_ARPACK

--- a/include/qudaQKXTM_Kepler_utils.h
+++ b/include/qudaQKXTM_Kepler_utils.h
@@ -66,7 +66,12 @@ namespace quda {
     FILE_WRITE_FORMAT CorrFileFormat;
     SOURCE_T source_type;
     CORR_SPACE CorrSpace;
+    bool HighMomForm;
     bool isEven;
+    double kappa;
+    double mu;
+    double csw;
+    double inv_tol;
   } qudaQKXTMinfo_Kepler;
   
   

--- a/qkxtm/CalcMG_2pt3pt_EvenOdd.cpp
+++ b/qkxtm/CalcMG_2pt3pt_EvenOdd.cpp
@@ -122,6 +122,7 @@ extern int Nproj;
 extern char proj_list_file[];
 
 extern char *corr_write_space;
+extern bool HighMomForm;
 
 namespace quda {
   extern void setTransferGPU(bool);
@@ -501,6 +502,11 @@ int main(int argc, char **argv)
   info.Nsources = numSourcePositions;
   info.Q_sq = Q_sq;
   info.traj = traj;
+  info.HighMomForm = HighMomForm;
+  info.kappa = kappa;
+  info.csw = csw;
+  info.mu = mu;
+  info.inv_tol = tol;
 
   if(strcmp(check_file_exist,"yes")==0 || 
      strcmp(check_file_exist,"YES")==0 )  info.check_files = true;

--- a/qkxtm/QKXTM_util.cpp
+++ b/qkxtm/QKXTM_util.cpp
@@ -1602,6 +1602,8 @@ char proj_list_file[257] = "default";
 
 char *corr_write_space = "MOMENTUM";
 
+bool HighMomForm = true;
+
 //-C.K. loop Parameters
 int Nstoch = 100;     // Number of stochastic noise vectors
 unsigned long int seed   = 100;  // The seed for the stochastic vectors
@@ -1820,6 +1822,7 @@ void usage(char** argv )
   printf("    --check-corr-files                        # check if 2pt-functions exist to avoid reproducing (default \"no\")\n");
   printf("    --proj-list                               # path to a file-list of projectors for 3pt function (default: only G4)\n");
   printf("    --corr-write-space                        # write the correlation functions in position space (MOMENTUM/POSITION, default: MOMENTUM)\n");
+  printf("    --HighMomForm                             # whether to write the correlation functions in HighMomentum Format (only for HDF5) (yes/no, default: yes)\n");
 
   //-C.K. Loop INPUT
   printf("    --Q-sqMax-loop                            # The maximum Q^2 momentum (loop) (default 0)\n");
@@ -1842,7 +1845,7 @@ void usage(char** argv )
   printf("    --pathEigenVectorsDown                    # Path where the eigenVectors for up flavor are (default ev_d.0000)\n");
   printf("    --pathEigenValuesUp                       # Path where the eigenVectors for up flavor are (default evals_u.dat)\n");
   printf("    --pathEigenValuesDown                     # Path where the eigenVectors for up flavor are (default evals_d.dat)\n");
-
+  
   //-C.K. ARPACK EXACT INPUT
   printf("    --PolyDeg                                 # The degree of the polynomial Acceleration (default 100)\n");
   printf("    --nEv                                     # Number of eigenvalues requested by ARPACK (default 100)\n");
@@ -1856,10 +1859,10 @@ void usage(char** argv )
   printf("    --amaxARPACK                              # amax parameter used in Cheb. Poly. Acc. (default 3.5)\n");
   printf("    --UseFullOp                               # Whether to use the Full Operator (yes,no, default no)\n");
   printf("    --defl_steps                              # File to deflation steps (default none)\n");
-
+  
 #endif
   //--------//
-
+  
   printf("    --help                                    # Print out this message\n"); 
   usage_extra(argv); 
 #ifdef MULTI_GPU
@@ -1871,7 +1874,7 @@ void usage(char** argv )
   exit(1);
   return ;
 }
-
+ 
 int process_command_line_option(int argc, char** argv, int* idx)
 {
 #ifdef MULTI_GPU
@@ -1879,20 +1882,20 @@ int process_command_line_option(int argc, char** argv, int* idx)
 #else
   char msg[]="single";
 #endif
-
+  
   int ret = -1;
   
   int i = *idx;
-
+  
   if( strcmp(argv[i], "--help")== 0){
     usage(argv);
   }
-
+  
   if( strcmp(argv[i], "--verify") == 0){
     if (i+1 >= argc){
       usage(argv);
     }	    
-
+    
     if (strcmp(argv[i+1], "true") == 0){
       verify_results = true;
     }else if (strcmp(argv[i+1], "false") == 0){
@@ -3025,6 +3028,18 @@ int process_command_line_option(int argc, char** argv, int* idx)
       usage(argv);
     }    
     corr_write_space = strdup(argv[i+1]);
+    i++;
+    ret = 0;
+    goto out;
+  }
+
+  if( strcmp(argv[i], "--HighMomForm") ==0){
+    if(i+1 >= argc){
+      usage(argv);
+    }
+    if( strcmp(argv[i+1],"yes")==0 || strcmp(argv[i+1],"YES")==0 ) HighMomForm = true;
+    else if ( strcmp(argv[i+1],"no")==0 || strcmp(argv[i+1],"NO")==0 ) HighMomForm = false;
+    else usage(argv);
     i++;
     ret = 0;
     goto out;


### PR DESCRIPTION
With this commit, the correlation functions can be written in a more efficient form in the HDF5 format, particularly applicable for high values of the Q-square. Also included are attributes related to the ensemble being used.